### PR TITLE
Fix sing clip description, add copy-to and sing fallback UI, show pac…

### DIFF
--- a/client/src/components/instructions/InstructionsPage.tsx
+++ b/client/src/components/instructions/InstructionsPage.tsx
@@ -169,6 +169,13 @@ export function InstructionsPage() {
           <li>
             Gender limits which cats can use the pack. Male voices go to male cats, female to female.
           </li>
+          <li>
+            <span className="text-mew-text font-medium">Sing clips</span> are
+            not a cat singing a melody — they're a very short meow the game
+            repeats rapidly at different pitches to emulate singing. Keep them
+            under ~0.7s. If you skip Sing, the game uses your first Normal clip
+            as a fallback.
+          </li>
         </ul>
       </section>
 

--- a/client/src/components/pack-builder/PackBuilder.tsx
+++ b/client/src/components/pack-builder/PackBuilder.tsx
@@ -102,6 +102,27 @@ export function PackBuilder() {
     });
   }, []);
 
+  const handleCopyClip = useCallback((clipId: string, fromAction: VoiceAction, toAction: VoiceAction) => {
+    setPack((prev) => {
+      const clipToCopy = prev.clips[fromAction].find(c => c.id === clipId);
+      if (!clipToCopy) return prev;
+
+      const copiedClip: AudioClip = {
+        ...clipToCopy,
+        id: `${clipToCopy.id}_copy_${Date.now()}`,
+        action: toAction,
+      };
+
+      return {
+        ...prev,
+        clips: {
+          ...prev.clips,
+          [toAction]: [...prev.clips[toAction], copiedClip],
+        }
+      };
+    });
+  }, []);
+
 
 
   const handleBuild = async () => {
@@ -270,10 +291,12 @@ export function PackBuilder() {
               key={action}
               action={action}
               clips={pack.clips[action]}
+              normalClips={action === 'Sing' ? pack.clips.Normal : undefined}
               onAddClip={handleAddClip}
               onRemoveClip={(clipId) => handleRemoveClip(action, clipId)}
               onUpdateClip={handleUpdateClip}
               onMoveClip={(clipId, toAction) => handleMoveClip(clipId, action, toAction)}
+              onCopyClip={(clipId, toAction, fromAction) => handleCopyClip(clipId, fromAction || action, toAction)}
             />
           ))}
         </div>

--- a/client/src/components/recorder/ActionRecorder.tsx
+++ b/client/src/components/recorder/ActionRecorder.tsx
@@ -3,6 +3,7 @@ import { useAudioRecorder } from '@/hooks/useAudioRecorder';
 import {
   VoiceAction,
   AudioClip,
+  VOICE_ACTIONS,
   ACTION_DESCRIPTIONS,
   ACTION_RECOMMENDED_CLIPS,
   CORE_ACTIONS,
@@ -16,13 +17,16 @@ import { TrimModal } from '@/components/recorder/TrimModal';
 interface ActionRecorderProps {
   action: VoiceAction;
   clips: AudioClip[];
+  /** Normal clips passed to the Sing section for fallback display */
+  normalClips?: AudioClip[];
   onAddClip: (clip: AudioClip) => void;
   onRemoveClip: (clipId: string) => void;
   onUpdateClip: (clip: AudioClip) => void;
   onMoveClip: (clipId: string, toAction: VoiceAction) => void;
+  onCopyClip: (clipId: string, toAction: VoiceAction, fromAction?: VoiceAction) => void;
 }
 
-export function ActionRecorder({ action, clips, onAddClip, onRemoveClip, onUpdateClip, onMoveClip }: ActionRecorderProps) {
+export function ActionRecorder({ action, clips, normalClips, onAddClip, onRemoveClip, onUpdateClip, onMoveClip, onCopyClip }: ActionRecorderProps) {
   const {
     isRecording,
     stream,
@@ -167,30 +171,45 @@ export function ActionRecorder({ action, clips, onAddClip, onRemoveClip, onUpdat
                 <button
                   onClick={() => setIsMoveMenuOpen(isMoveMenuOpen === clip.id ? null : clip.id)}
                   className={`text-sm px-1.5 py-0.5 rounded transition-colors ${isMoveMenuOpen === clip.id ? 'text-mew-accent bg-mew-highlight/30' : 'text-mew-muted hover:text-mew-accent hover:bg-mew-highlight/30'}`}
-                  title="Move to another category"
+                  title="Move or copy to another category"
                 >
                   ➔
                 </button>
 
                 {isMoveMenuOpen === clip.id && (
                   <>
-                    {/* Backdrop to close */}
                     <div className="fixed inset-0 z-10" onClick={() => setIsMoveMenuOpen(null)} />
 
-                    <div className="absolute right-0 top-full mt-1 w-32 bg-mew-surface border border-mew-highlight/50 rounded-lg shadow-xl z-20 max-h-48 overflow-y-auto">
-                      {Object.keys(ACTION_RECOMMENDED_CLIPS).map((targetAction) => (
-                        targetAction !== action && (
-                          <button
-                            key={targetAction}
-                            onClick={() => {
-                              onMoveClip(clip.id, targetAction as VoiceAction);
-                              setIsMoveMenuOpen(null);
-                            }}
-                            className="block w-full text-left px-3 py-2 text-xs text-mew-text hover:bg-mew-accent/20 first:rounded-t-lg last:rounded-b-lg"
-                          >
-                            {targetAction}
-                          </button>
-                        )
+                    <div className="absolute right-0 top-full mt-1 w-40 bg-mew-surface border border-mew-highlight/50 rounded-lg shadow-xl z-20 max-h-64 overflow-y-auto">
+                      <div className="px-3 py-1.5 text-[10px] font-semibold text-mew-muted/60 uppercase tracking-wider border-b border-mew-highlight/20">
+                        Move to
+                      </div>
+                      {VOICE_ACTIONS.filter(a => a !== action).map((targetAction) => (
+                        <button
+                          key={`move-${targetAction}`}
+                          onClick={() => {
+                            onMoveClip(clip.id, targetAction);
+                            setIsMoveMenuOpen(null);
+                          }}
+                          className="block w-full text-left px-3 py-1.5 text-xs text-mew-text hover:bg-mew-accent/20"
+                        >
+                          {targetAction}
+                        </button>
+                      ))}
+                      <div className="px-3 py-1.5 text-[10px] font-semibold text-mew-muted/60 uppercase tracking-wider border-t border-b border-mew-highlight/20">
+                        Copy to
+                      </div>
+                      {VOICE_ACTIONS.filter(a => a !== action).map((targetAction) => (
+                        <button
+                          key={`copy-${targetAction}`}
+                          onClick={() => {
+                            onCopyClip(clip.id, targetAction);
+                            setIsMoveMenuOpen(null);
+                          }}
+                          className="block w-full text-left px-3 py-1.5 text-xs text-mew-text hover:bg-mew-accent/20 last:rounded-b-lg"
+                        >
+                          {targetAction}
+                        </button>
                       ))}
                     </div>
                   </>
@@ -211,6 +230,11 @@ export function ActionRecorder({ action, clips, onAddClip, onRemoveClip, onUpdat
             </div>
           ))}
         </div>
+      )}
+
+      {/* Sing fallback indicator: show which Normal clip the game will use */}
+      {action === 'Sing' && clips.length === 0 && normalClips && normalClips.length > 0 && (
+        <SingFallbackDisplay normalClips={normalClips} onCopyToSing={onCopyClip} />
       )}
 
       {/* Record / Upload controls */}
@@ -279,6 +303,79 @@ export function ActionRecorder({ action, clips, onAddClip, onRemoveClip, onUpdat
           onClose={() => setTrimmingClip(null)}
         />
       )}
+    </div>
+  );
+}
+
+/**
+ * Shows which Normal clips will be used as sing fallback, ranked by suitability.
+ *
+ * Selection logic: shorter Normal clips are better for singing because the game
+ * repeats them rapidly at different pitches. We rank by duration (ascending) and
+ * highlight the first Normal clip since that's what the GON fallback actually uses.
+ */
+function SingFallbackDisplay({
+  normalClips,
+  onCopyToSing,
+}: {
+  normalClips: AudioClip[];
+  onCopyToSing: (clipId: string, toAction: VoiceAction, fromAction?: VoiceAction) => void;
+}) {
+  // Rank Normal clips by suitability for singing: shorter = better
+  const ranked = [...normalClips]
+    .map((clip, originalIndex) => ({ clip, originalIndex }))
+    .sort((a, b) => a.clip.duration - b.clip.duration);
+
+  // The GON fallback uses Normal[0] (the first Normal clip by order, not by duration)
+  const fallbackClipId = normalClips[0]?.id;
+
+  return (
+    <div className="mb-4 rounded-lg border border-amber-700/30 bg-amber-900/10 p-3">
+      <p className="text-xs text-amber-400 font-medium mb-2">
+        No sing clips uploaded — the game will repeat your first Normal clip at
+        varying pitches to emulate singing. Shorter clips work best.
+      </p>
+      <div className="space-y-1.5">
+        {ranked.map(({ clip, originalIndex }) => {
+          const isFallback = clip.id === fallbackClipId;
+          const isShort = clip.duration <= 1.0;
+          return (
+            <div
+              key={clip.id}
+              className={`flex items-center gap-2 p-1.5 rounded text-xs ${
+                isFallback
+                  ? 'bg-amber-900/30 border border-amber-700/40'
+                  : 'bg-mew-bg/30'
+              }`}
+            >
+              <span className="text-mew-muted w-10 flex-shrink-0">
+                N#{originalIndex + 1}
+              </span>
+              <audio src={clip.url} controls className="h-7 flex-1" />
+              <span className={`flex-shrink-0 ${isShort ? 'text-green-400' : 'text-mew-muted'}`}>
+                {clip.duration.toFixed(1)}s
+              </span>
+              {isFallback && (
+                <span className="text-[10px] px-1.5 py-0.5 rounded bg-amber-800/50 text-amber-300 flex-shrink-0">
+                  active fallback
+                </span>
+              )}
+              {isShort && !isFallback && (
+                <span className="text-[10px] text-green-400/70 flex-shrink-0">
+                  good fit
+                </span>
+              )}
+              <button
+                onClick={() => onCopyToSing(clip.id, 'Sing', 'Normal')}
+                className="text-mew-accent hover:text-mew-accent/80 text-[10px] px-1.5 py-0.5 rounded bg-mew-accent/10 hover:bg-mew-accent/20 transition-colors flex-shrink-0"
+                title="Copy this clip to Sing"
+              >
+                Copy to Sing
+              </button>
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/client/src/types/voicepack.ts
+++ b/client/src/types/voicepack.ts
@@ -37,7 +37,7 @@ export const ACTION_DESCRIPTIONS: Record<VoiceAction, string> = {
   Sad: 'Sad meows — whimpering, whining, lonely sounds (~1.2s each)',
   Hiss: 'Hissing and spitting — defensive warning sounds. Optional, but most packs include them (~1.1s each)',
   Purr: 'Purring — longer, sustained relaxed sounds. Optional (~1.6s each)',
-  Sing: 'Singing — melodic meow. Most packs skip this entirely, totally optional (~0.7s each)',
+  Sing: 'Singing — a very short meow the game repeats at different pitches to emulate a song. Keep it punchy (~0.7s). If empty, your first Normal clip is used instead',
 };
 
 /**

--- a/desktop/src/components/panels/InstalledPacksPanel.tsx
+++ b/desktop/src/components/panels/InstalledPacksPanel.tsx
@@ -133,9 +133,13 @@ function PackRow({
   onSetFrequency: (freq: number) => void;
   onUninstall: () => void;
 }) {
+  const totalClips = pack.clipCounts
+    ? Object.values(pack.clipCounts).reduce((sum, n) => sum + n, 0)
+    : 0;
+
   return (
     <div
-      className={`flex items-center gap-4 p-3 rounded-lg border transition-colors ${
+      className={`flex items-start gap-4 p-4 rounded-lg border transition-colors ${
         pack.isEnabled
           ? 'bg-mew-surface border-mew-highlight/40'
           : 'bg-mew-surface/50 border-mew-highlight/20 opacity-60'
@@ -144,7 +148,7 @@ function PackRow({
       {/* Toggle */}
       <button
         onClick={onToggle}
-        className={`w-10 h-5 rounded-full relative transition-colors flex-shrink-0 ${
+        className={`w-10 h-5 rounded-full relative transition-colors flex-shrink-0 mt-1 ${
           pack.isEnabled ? 'bg-mew-accent' : 'bg-mew-highlight'
         }`}
       >
@@ -168,19 +172,26 @@ function PackRow({
             </span>
           )}
         </div>
-        <p className="text-xs text-mew-muted truncate">
-          {pack.author && `by ${pack.author} · `}
-          {pack.folderName}
-        </p>
+        {pack.author && (
+          <p className="text-sm text-mew-muted mt-0.5">
+            by {pack.author}
+          </p>
+        )}
         {pack.description && (
-          <p className="text-xs text-mew-muted/50 truncate mt-0.5">
+          <p className="text-xs text-mew-muted/70 mt-1 line-clamp-2">
             {pack.description}
           </p>
         )}
+        <div className="flex items-center gap-3 mt-1.5 text-xs text-mew-muted/60">
+          {totalClips > 0 && (
+            <span>{totalClips} clip{totalClips !== 1 ? 's' : ''}</span>
+          )}
+          <span className="text-mew-muted/40">{pack.folderName}</span>
+        </div>
       </div>
 
       {/* Frequency */}
-      <div className="flex items-center gap-1.5 flex-shrink-0">
+      <div className="flex items-center gap-1.5 flex-shrink-0 mt-1">
         <label className="text-xs text-mew-muted">Weight:</label>
         <input
           type="number"
@@ -201,7 +212,7 @@ function PackRow({
               onUninstall();
             }
           }}
-          className="text-red-400/60 hover:text-red-400 text-sm px-1 flex-shrink-0"
+          className="text-red-400/60 hover:text-red-400 text-sm px-1 flex-shrink-0 mt-1"
           title="Uninstall pack"
         >
           Remove


### PR DESCRIPTION
- Correct sing clip description: short meow repeated at different pitches, not a melodic performance. Updated in voicepack.ts and InstructionsPage.
- Add "Copy to" option alongside "Move to" in clip dropdown menu, allowing clips to be duplicated across categories without removing the original.
- Show sing fallback indicator when no sing clips are uploaded: displays all Normal clips ranked by duration (shorter = better for singing), highlights the first Normal clip as the active GON fallback, and provides one-click "Copy to Sing" buttons.
- Desktop installed packs panel now shows author, description (up to 2 lines), and total clip count for each voice pack.