### PR TITLE
Remove unused shell plugin and tighten Tauri security config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
           prerelease: false
           projectPath: ./desktop
 
-      # ── Hash & AV reputation steps ──────────────────────────────────────────
+      # ── Hash (AV reputation runs in reputation.yml on release publish) ──────
 
       - name: Locate installer and compute SHA-256
         id: hash
@@ -68,45 +68,4 @@ jobs:
           $version = (Get-Content desktop/src-tauri/tauri.conf.json | ConvertFrom-Json).version
           gh release upload "MewVoice-v$version" "${{ steps.hash.outputs.sha_file }}" --clobber
 
-      - name: Submit to VirusTotal
-        if: ${{ secrets.VIRUSTOTAL_API_KEY != '' }}
-        shell: pwsh
-        env:
-          VT_API_KEY: ${{ secrets.VIRUSTOTAL_API_KEY }}
-        run: |
-          $hash    = "${{ steps.hash.outputs.sha256 }}"
-          $headers = @{ "x-apikey" = $env:VT_API_KEY }
 
-          try {
-            # Check if this exact file hash is already in VT's database
-            $null = Invoke-RestMethod "https://www.virustotal.com/api/v3/files/$hash" -Headers $headers
-            Write-Host "Hash already known to VirusTotal — skipping upload."
-          } catch {
-            # 404 = not yet seen; upload the binary for a fresh scan
-            Write-Host "Hash not yet known — uploading installer to VirusTotal..."
-            $resp = Invoke-RestMethod "https://www.virustotal.com/api/v3/files" -Method Post `
-              -Headers $headers `
-              -Form @{ file = Get-Item "${{ steps.hash.outputs.installer_path }}" }
-            Write-Host "Queued. Analysis ID: $($resp.data.id)"
-          }
-
-          Write-Host "Results: https://www.virustotal.com/gui/file/$hash"
-
-      - name: Write job summary
-        shell: pwsh
-        run: |
-          $hash = "${{ steps.hash.outputs.sha256 }}"
-          $name = "${{ steps.hash.outputs.installer_name }}"
-          @"
-          ## Release Checksums
-
-          | File | SHA-256 |
-          |------|---------|
-          | ``$name`` | ``$hash`` |
-
-          ## AV Reputation Submissions
-
-          - **VirusTotal**: https://www.virustotal.com/gui/file/$hash
-          - **Microsoft WDSI** *(manual)*: https://www.microsoft.com/en-us/wdsi/filesubmission
-            - Submit hash ``$hash`` or upload the installer directly.
-          "@ | Out-File -Append -FilePath $env:GITHUB_STEP_SUMMARY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,9 @@ jobs:
       - name: install frontend dependencies
         run: npm install
         working-directory: ./desktop
-      - uses: tauri-apps/tauri-action@v0
+      - name: build and publish release
+        id: tauri
+        uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
@@ -31,3 +33,80 @@ jobs:
           releaseDraft: true
           prerelease: false
           projectPath: ./desktop
+
+      # ── Hash & AV reputation steps ──────────────────────────────────────────
+
+      - name: Locate installer and compute SHA-256
+        id: hash
+        shell: pwsh
+        run: |
+          $exe = Get-ChildItem -Recurse "desktop/src-tauri/target/release/bundle/nsis" `
+                   -Filter "*-setup.exe" -ErrorAction SilentlyContinue |
+                 Select-Object -First 1
+          if (-not $exe) {
+            Write-Warning "NSIS installer not found, falling back to MSI"
+            $exe = Get-ChildItem -Recurse "desktop/src-tauri/target/release/bundle/msi" `
+                     -Filter "*.msi" -ErrorAction SilentlyContinue |
+                   Select-Object -First 1
+          }
+          if (-not $exe) { Write-Error "No installer artifact found"; exit 1 }
+
+          $hash    = (Get-FileHash $exe.FullName -Algorithm SHA256).Hash.ToLower()
+          $shaFile = Join-Path $env:RUNNER_TEMP "$($exe.BaseName).sha256"
+          "$hash  $($exe.Name)" | Out-File -FilePath $shaFile -Encoding ASCII
+
+          "sha256=$hash"                  | Out-File -Append $env:GITHUB_OUTPUT
+          "installer_path=$($exe.FullName)" | Out-File -Append $env:GITHUB_OUTPUT
+          "sha_file=$shaFile"             | Out-File -Append $env:GITHUB_OUTPUT
+          "installer_name=$($exe.Name)"  | Out-File -Append $env:GITHUB_OUTPUT
+
+      - name: Upload SHA-256 checksum to release
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $version = (Get-Content desktop/src-tauri/tauri.conf.json | ConvertFrom-Json).version
+          gh release upload "MewVoice-v$version" "${{ steps.hash.outputs.sha_file }}" --clobber
+
+      - name: Submit to VirusTotal
+        if: ${{ secrets.VIRUSTOTAL_API_KEY != '' }}
+        shell: pwsh
+        env:
+          VT_API_KEY: ${{ secrets.VIRUSTOTAL_API_KEY }}
+        run: |
+          $hash    = "${{ steps.hash.outputs.sha256 }}"
+          $headers = @{ "x-apikey" = $env:VT_API_KEY }
+
+          try {
+            # Check if this exact file hash is already in VT's database
+            $null = Invoke-RestMethod "https://www.virustotal.com/api/v3/files/$hash" -Headers $headers
+            Write-Host "Hash already known to VirusTotal — skipping upload."
+          } catch {
+            # 404 = not yet seen; upload the binary for a fresh scan
+            Write-Host "Hash not yet known — uploading installer to VirusTotal..."
+            $resp = Invoke-RestMethod "https://www.virustotal.com/api/v3/files" -Method Post `
+              -Headers $headers `
+              -Form @{ file = Get-Item "${{ steps.hash.outputs.installer_path }}" }
+            Write-Host "Queued. Analysis ID: $($resp.data.id)"
+          }
+
+          Write-Host "Results: https://www.virustotal.com/gui/file/$hash"
+
+      - name: Write job summary
+        shell: pwsh
+        run: |
+          $hash = "${{ steps.hash.outputs.sha256 }}"
+          $name = "${{ steps.hash.outputs.installer_name }}"
+          @"
+          ## Release Checksums
+
+          | File | SHA-256 |
+          |------|---------|
+          | ``$name`` | ``$hash`` |
+
+          ## AV Reputation Submissions
+
+          - **VirusTotal**: https://www.virustotal.com/gui/file/$hash
+          - **Microsoft WDSI** *(manual)*: https://www.microsoft.com/en-us/wdsi/filesubmission
+            - Submit hash ``$hash`` or upload the installer directly.
+          "@ | Out-File -Append -FilePath $env:GITHUB_STEP_SUMMARY

--- a/.github/workflows/reputation.yml
+++ b/.github/workflows/reputation.yml
@@ -1,0 +1,83 @@
+name: 'reputation'
+on:
+  release:
+    types: [published]
+
+# Only runs when a draft is promoted to a real release, so every submission
+# corresponds to a binary that was actually shipped.
+jobs:
+  av-submission:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Fetch hash from release assets
+        id: hash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release download "${{ github.event.release.tag_name }}" \
+            --repo "${{ github.repository }}" \
+            --pattern "*.sha256" \
+            --dir "$RUNNER_TEMP"
+
+          sha_file=$(find "$RUNNER_TEMP" -name "*.sha256" | head -1)
+          content=$(cat "$sha_file")
+          # File format written by release.yml: "<hash>  <filename>"
+          hash=$(awk '{print $1}' <<< "$content")
+          name=$(awk '{print $2}' <<< "$content")
+
+          echo "sha256=$hash"        >> "$GITHUB_OUTPUT"
+          echo "installer_name=$name" >> "$GITHUB_OUTPUT"
+
+      - name: Submit to VirusTotal
+        if: secrets.VIRUSTOTAL_API_KEY != ''
+        env:
+          VT_API_KEY: ${{ secrets.VIRUSTOTAL_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          hash="${{ steps.hash.outputs.sha256 }}"
+          name="${{ steps.hash.outputs.installer_name }}"
+          tag="${{ github.event.release.tag_name }}"
+
+          http_code=$(curl -s -o /dev/null -w "%{http_code}" \
+            -H "x-apikey: $VT_API_KEY" \
+            "https://www.virustotal.com/api/v3/files/$hash")
+
+          if [ "$http_code" = "200" ]; then
+            echo "Hash already known to VirusTotal — skipping upload."
+          else
+            echo "Hash not yet known — downloading installer from release and uploading..."
+            gh release download "$tag" \
+              --repo "${{ github.repository }}" \
+              --pattern "$name" \
+              --dir "$RUNNER_TEMP"
+
+            analysis_id=$(curl -s \
+              -H "x-apikey: $VT_API_KEY" \
+              -F "file=@$RUNNER_TEMP/$name" \
+              "https://www.virustotal.com/api/v3/files" \
+              | jq -r '.data.id')
+            echo "Queued. Analysis ID: $analysis_id"
+          fi
+
+          echo "Results: https://www.virustotal.com/gui/file/$hash"
+
+      - name: Write job summary
+        run: |
+          hash="${{ steps.hash.outputs.sha256 }}"
+          name="${{ steps.hash.outputs.installer_name }}"
+          tag="${{ github.event.release.tag_name }}"
+          cat >> "$GITHUB_STEP_SUMMARY" << EOF
+          ## Release Checksums
+
+          | File | SHA-256 |
+          |------|---------|
+          | \`$name\` | \`$hash\` |
+
+          ## AV Reputation Submissions
+
+          - **VirusTotal**: https://www.virustotal.com/gui/file/$hash
+          - **Microsoft WDSI** *(manual)*: https://www.microsoft.com/en-us/wdsi/filesubmission
+            - Submit hash \`$hash\` or upload the installer directly.
+          EOF

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mewvoice-desktop"
-version = "0.1.0"
+version = "0.2.0"
 description = "MewVoice - Voice Pack Manager for Mewgenics"
 authors = ["MewVoice"]
 license = ""

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -25,6 +25,5 @@ tauri = { version = "2", features = [] }
 tauri-plugin-log = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
-tauri-plugin-shell = "2"
 zip = "2"
 uuid = { version = "1", features = ["v4"] }

--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -7,9 +7,6 @@
     "core:default",
     "dialog:default",
     "dialog:allow-open",
-    "dialog:allow-save",
-    "fs:default",
-    "shell:default",
-    "shell:allow-open"
+    "fs:default"
   ]
 }

--- a/desktop/src-tauri/src/commands/install.rs
+++ b/desktop/src-tauri/src/commands/install.rs
@@ -26,6 +26,7 @@ pub fn install_pack(zip_path: String, mod_root: String) -> Result<String, String
     let mut description = String::new();
     let mut folder_name = String::new();
     let mut clip_counts: serde_json::Map<String, serde_json::Value> = serde_json::Map::new();
+    let mut pack_tool_version = String::new();
 
     // Try to find description.json or metadata_*.json
     for i in 0..archive.len() {
@@ -66,6 +67,9 @@ pub fn install_pack(zip_path: String, mod_root: String) -> Result<String, String
                     if let Some(pn) = meta.get("pack_name").and_then(|v| v.as_str()) {
                         folder_name = pn.to_string();
                     }
+                    if let Some(tv) = meta.get("tool_version").and_then(|v| v.as_str()) {
+                        pack_tool_version = tv.to_string();
+                    }
                 }
             }
         }
@@ -100,6 +104,32 @@ pub fn install_pack(zip_path: String, mod_root: String) -> Result<String, String
     if pack_name.is_empty() {
         pack_name = folder_name.clone();
     }
+
+    // Version compatibility check — only runs when the pack carries a tool_version
+    let compatibility_warning: Option<String> = if !pack_tool_version.is_empty() {
+        let app_ver = env!("CARGO_PKG_VERSION");
+        match (parse_semver(&pack_tool_version), parse_semver(app_ver)) {
+            (Some((pack_maj, pack_min, _)), Some((app_maj, app_min, _))) => {
+                if pack_maj > app_maj {
+                    return Err(format!(
+                        "This pack requires MewVoice v{pack_tool_version} or later. \
+                         Please update the MewVoice desktop app before installing."
+                    ));
+                } else if pack_maj == app_maj && pack_min > app_min {
+                    Some(format!(
+                        "This pack was built with MewVoice v{pack_tool_version}, which is newer \
+                         than your installed version (v{app_ver}). \
+                         It should still work, but consider updating."
+                    ))
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    } else {
+        None
+    };
 
     // The voice_set ID is the folder_name (this is what goes in catgen.gon)
     let voice_set_id = folder_name.clone();
@@ -140,7 +170,7 @@ pub fn install_pack(zip_path: String, mod_root: String) -> Result<String, String
     }
 
     // Build result JSON matching InstalledVoicePack interface
-    let result = serde_json::json!({
+    let mut result = serde_json::json!({
         "id": voice_set_id,
         "name": pack_name,
         "folderName": folder_name,
@@ -153,7 +183,11 @@ pub fn install_pack(zip_path: String, mod_root: String) -> Result<String, String
         "isBasePack": false,
         "installedAt": chrono_now(),
         "clipCounts": clip_counts,
+        "toolVersion": pack_tool_version,
     });
+    if let Some(warning) = compatibility_warning {
+        result["compatibilityWarning"] = serde_json::Value::String(warning);
+    }
 
     log::info!("Installed voice pack: {} ({})", pack_name, voice_set_id);
     Ok(result.to_string())
@@ -181,6 +215,15 @@ pub fn uninstall_pack(mod_root: String, folder_name: String) -> Result<(), Strin
 
     log::info!("Uninstalled voice pack: {}", folder_name);
     Ok(())
+}
+
+/// Parse "major.minor.patch" into a numeric triple, returning None on malformed input.
+fn parse_semver(v: &str) -> Option<(u32, u32, u32)> {
+    let mut parts = v.splitn(3, '.');
+    let maj = parts.next()?.parse().ok()?;
+    let min = parts.next()?.parse().ok()?;
+    let pat = parts.next()?.parse().ok()?;
+    Some((maj, min, pat))
 }
 
 /// Simple ISO timestamp without chrono dependency

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -5,7 +5,6 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
-        .plugin(tauri_plugin_shell::init())
         .setup(|app| {
             if cfg!(debug_assertions) {
                 app.handle().plugin(

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -22,7 +22,7 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; media-src 'self' blob:; connect-src 'self' ipc: http://ipc.localhost https://ipc.localhost"
     }
   },
   "bundle": {

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "MewVoice",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "identifier": "com.mewvoice.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+/**
+ * Version bump script for MewVoice.
+ *
+ * Updates the three places that must stay in sync:
+ *   - desktop/src-tauri/tauri.conf.json   (drives GitHub release tags & installer names)
+ *   - desktop/src-tauri/Cargo.toml        (must match tauri.conf.json at Tauri build time)
+ *   - worker/src/lib/zip.ts               (embedded in every voice pack for compatibility checks)
+ *
+ * Usage:
+ *   node scripts/bump-version.js <major.minor.patch>
+ *
+ * Example:
+ *   node scripts/bump-version.js 0.2.0
+ */
+
+'use strict';
+
+const { readFileSync, writeFileSync } = require('fs');
+const { resolve } = require('path');
+
+const root = resolve(__dirname, '..');
+const newVersion = process.argv[2];
+
+if (!newVersion || !/^\d+\.\d+\.\d+$/.test(newVersion)) {
+  console.error('Usage: node scripts/bump-version.js <major.minor.patch>');
+  process.exit(1);
+}
+
+// ── 1. desktop/src-tauri/tauri.conf.json ─────────────────────────────────────
+const tauriConfPath = resolve(root, 'desktop/src-tauri/tauri.conf.json');
+const tauriConf = JSON.parse(readFileSync(tauriConfPath, 'utf8'));
+const oldVersion = tauriConf.version;
+tauriConf.version = newVersion;
+writeFileSync(tauriConfPath, JSON.stringify(tauriConf, null, 2) + '\n');
+console.log(`tauri.conf.json:       ${oldVersion} → ${newVersion}`);
+
+// ── 2. desktop/src-tauri/Cargo.toml ──────────────────────────────────────────
+const cargoPath = resolve(root, 'desktop/src-tauri/Cargo.toml');
+const cargo = readFileSync(cargoPath, 'utf8');
+// Only replace the [package] version, not dependency versions
+const updatedCargo = cargo.replace(
+  /^(version\s*=\s*)"[\d.]+"(\s*$)/m,
+  `$1"${newVersion}"$2`,
+);
+if (updatedCargo === cargo) {
+  console.error('Cargo.toml: could not find package version line — check the file manually.');
+  process.exit(1);
+}
+writeFileSync(cargoPath, updatedCargo);
+console.log(`Cargo.toml:            ${oldVersion} → ${newVersion}`);
+
+// ── 3. worker/src/lib/zip.ts (MEWVOICE_TOOL_VERSION) ─────────────────────────
+const zipTsPath = resolve(root, 'worker/src/lib/zip.ts');
+const zipTs = readFileSync(zipTsPath, 'utf8');
+const updatedZipTs = zipTs.replace(
+  /^(export const MEWVOICE_TOOL_VERSION\s*=\s*)'[\d.]+'(;)/m,
+  `$1'${newVersion}'$2`,
+);
+if (updatedZipTs === zipTs) {
+  console.error('zip.ts: could not find MEWVOICE_TOOL_VERSION — check the file manually.');
+  process.exit(1);
+}
+writeFileSync(zipTsPath, updatedZipTs);
+console.log(`zip.ts TOOL_VERSION:   ${oldVersion} → ${newVersion}`);
+
+console.log(`\nDone. Stage and commit these files, then push to trigger a release build:\n`);
+console.log(`  git add desktop/src-tauri/tauri.conf.json`);
+console.log(`  git add desktop/src-tauri/Cargo.toml`);
+console.log(`  git add worker/src/lib/zip.ts`);
+console.log(`  git commit -m "chore: bump version to ${newVersion}"`);

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -2,16 +2,17 @@
 /**
  * Version bump script for MewVoice.
  *
- * Updates the three places that must stay in sync:
+ * Updates the four places that must stay in sync:
  *   - desktop/src-tauri/tauri.conf.json   (drives GitHub release tags & installer names)
  *   - desktop/src-tauri/Cargo.toml        (must match tauri.conf.json at Tauri build time)
+ *   - desktop/package.json                (kept in sync for developer hygiene)
  *   - worker/src/lib/zip.ts               (embedded in every voice pack for compatibility checks)
  *
  * Usage:
  *   node scripts/bump-version.js <major.minor.patch>
  *
  * Example:
- *   node scripts/bump-version.js 0.2.0
+ *   node scripts/bump-version.js 0.3.0
  */
 
 'use strict';
@@ -27,10 +28,39 @@ if (!newVersion || !/^\d+\.\d+\.\d+$/.test(newVersion)) {
   process.exit(1);
 }
 
-// ── 1. desktop/src-tauri/tauri.conf.json ─────────────────────────────────────
+// ── Read current version from tauri.conf.json (single source of truth) ────────
 const tauriConfPath = resolve(root, 'desktop/src-tauri/tauri.conf.json');
 const tauriConf = JSON.parse(readFileSync(tauriConfPath, 'utf8'));
 const oldVersion = tauriConf.version;
+
+// ── Monotonicity guard ─────────────────────────────────────────────────────────
+function parseSemver(v) {
+  const m = v.match(/^(\d+)\.(\d+)\.(\d+)$/);
+  if (!m) return null;
+  return [parseInt(m[1], 10), parseInt(m[2], 10), parseInt(m[3], 10)];
+}
+
+const oldParts = parseSemver(oldVersion);
+const newParts = parseSemver(newVersion);
+
+if (!oldParts || !newParts) {
+  console.error(`Cannot parse version: old="${oldVersion}" new="${newVersion}"`);
+  process.exit(1);
+}
+
+const isGreater =
+  newParts[0] > oldParts[0] ||
+  (newParts[0] === oldParts[0] && newParts[1] > oldParts[1]) ||
+  (newParts[0] === oldParts[0] && newParts[1] === oldParts[1] && newParts[2] > oldParts[2]);
+
+if (!isGreater) {
+  console.error(
+    `Version must increase. Current is ${oldVersion}, refusing to set ${newVersion}.`,
+  );
+  process.exit(1);
+}
+
+// ── 1. desktop/src-tauri/tauri.conf.json ─────────────────────────────────────
 tauriConf.version = newVersion;
 writeFileSync(tauriConfPath, JSON.stringify(tauriConf, null, 2) + '\n');
 console.log(`tauri.conf.json:       ${oldVersion} → ${newVersion}`);
@@ -38,7 +68,7 @@ console.log(`tauri.conf.json:       ${oldVersion} → ${newVersion}`);
 // ── 2. desktop/src-tauri/Cargo.toml ──────────────────────────────────────────
 const cargoPath = resolve(root, 'desktop/src-tauri/Cargo.toml');
 const cargo = readFileSync(cargoPath, 'utf8');
-// Only replace the [package] version, not dependency versions
+// Only replace the [package] version line, not dependency versions
 const updatedCargo = cargo.replace(
   /^(version\s*=\s*)"[\d.]+"(\s*$)/m,
   `$1"${newVersion}"$2`,
@@ -50,7 +80,14 @@ if (updatedCargo === cargo) {
 writeFileSync(cargoPath, updatedCargo);
 console.log(`Cargo.toml:            ${oldVersion} → ${newVersion}`);
 
-// ── 3. worker/src/lib/zip.ts (MEWVOICE_TOOL_VERSION) ─────────────────────────
+// ── 3. desktop/package.json ───────────────────────────────────────────────────
+const desktopPkgPath = resolve(root, 'desktop/package.json');
+const desktopPkg = JSON.parse(readFileSync(desktopPkgPath, 'utf8'));
+desktopPkg.version = newVersion;
+writeFileSync(desktopPkgPath, JSON.stringify(desktopPkg, null, 2) + '\n');
+console.log(`desktop/package.json:  ${oldVersion} → ${newVersion}`);
+
+// ── 4. worker/src/lib/zip.ts (MEWVOICE_TOOL_VERSION) ─────────────────────────
 const zipTsPath = resolve(root, 'worker/src/lib/zip.ts');
 const zipTs = readFileSync(zipTsPath, 'utf8');
 const updatedZipTs = zipTs.replace(
@@ -67,5 +104,6 @@ console.log(`zip.ts TOOL_VERSION:   ${oldVersion} → ${newVersion}`);
 console.log(`\nDone. Stage and commit these files, then push to trigger a release build:\n`);
 console.log(`  git add desktop/src-tauri/tauri.conf.json`);
 console.log(`  git add desktop/src-tauri/Cargo.toml`);
+console.log(`  git add desktop/package.json`);
 console.log(`  git add worker/src/lib/zip.ts`);
 console.log(`  git commit -m "chore: bump version to ${newVersion}"`);

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -6,14 +6,29 @@ import { voicepackRoutes } from './routes/voicepacks';
 
 const app = new Hono<{ Bindings: Env }>();
 
-// CORS — in production, SPA and API share the same domain so CORS isn't
-// strictly needed, but we keep it for local dev (localhost:3000 → :8787)
+// CORS — in production, SPA and API share the same domain so this is only
+// needed for local dev (Vite :5173 → Worker :8787). Restrict to the site
+// origin and localhost to prevent other sites from making credentialed requests.
 app.use('/api/*', cors({
-  origin: (origin) => origin || '*',
+  origin: (origin, c) => {
+    const siteOrigin = (c.env as Env).SITE_ORIGIN;
+    if (origin === siteOrigin) return origin;
+    if (/^http:\/\/localhost(:\d+)?$/.test(origin)) return origin;
+    return null;
+  },
   credentials: true,
   allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
   allowHeaders: ['Content-Type'],
 }));
+
+// Security headers on every response
+app.use('*', async (c, next) => {
+  await next();
+  c.res.headers.set('X-Content-Type-Options', 'nosniff');
+  c.res.headers.set('X-Frame-Options', 'DENY');
+  c.res.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
+  c.res.headers.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
+});
 
 // Routes
 app.route('/api/auth', authRoutes);

--- a/worker/src/lib/zip.ts
+++ b/worker/src/lib/zip.ts
@@ -4,6 +4,13 @@
 import JSZip from 'jszip';
 import { generateVoiceGon } from './gon';
 
+/**
+ * The version of MewVoice that built this pack.
+ * Updated by scripts/bump-version.js alongside the desktop app version.
+ * The desktop app uses this to verify compatibility when loading a pack.
+ */
+export const MEWVOICE_TOOL_VERSION = '0.2.0';
+
 export interface BuildMetadata {
   name: string;
   author: string;
@@ -13,6 +20,7 @@ export interface BuildMetadata {
   build_id: string;
   clip_counts: Record<string, number>;
   created_at: string;
+  tool_version: string;
 }
 
 /**

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -10,7 +10,9 @@ export const authRoutes = new Hono<{ Bindings: Env }>();
 authRoutes.get('/steam/login', async (c) => {
   const env = c.env;
 
-  if (env.DEV_STEAM_ID) {
+  // Dev bypass: only active when running locally (non-HTTPS). Setting
+  // DEV_STEAM_ID in a production Cloudflare secret has no effect.
+  if (env.DEV_STEAM_ID && !env.SITE_ORIGIN.startsWith('https://')) {
     const profile = await fetchSteamProfile(env.DEV_STEAM_ID, env.STEAM_API_KEY);
     const token = await createJwtToken(profile, env.JWT_SECRET);
     setCookie(c, COOKIE_NAME, token, {

--- a/worker/src/routes/voicepacks.ts
+++ b/worker/src/routes/voicepacks.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 import type { Env, PackRowWithVote } from '../types';
 import { VALID_ACTIONS, RECOMMENDED_CLIPS, packRowToMeta } from '../types';
 import { validateWav } from '../lib/wav';
-import { buildVoicePackZip, listWavFiles, extractFile } from '../lib/zip';
+import { buildVoicePackZip, listWavFiles, extractFile, MEWVOICE_TOOL_VERSION } from '../lib/zip';
 import { getCurrentUser, requireUser } from './auth';
 
 export const voicepackRoutes = new Hono<{ Bindings: Env }>();
@@ -98,6 +98,7 @@ voicepackRoutes.post('/build', async (c) => {
     build_id: buildId,
     clip_counts: clipCounts,
     created_at: new Date().toISOString(),
+    tool_version: MEWVOICE_TOOL_VERSION,
   };
 
   // Build ZIP in memory

--- a/worker/src/routes/voicepacks.ts
+++ b/worker/src/routes/voicepacks.ts
@@ -120,6 +120,7 @@ voicepackRoutes.post('/build', async (c) => {
     id: buildId,
     packName,
     downloadUrl: `/api/voicepacks/${buildId}/download`,
+    tool_version: MEWVOICE_TOOL_VERSION,
   });
 });
 

--- a/worker/src/routes/voicepacks.ts
+++ b/worker/src/routes/voicepacks.ts
@@ -7,8 +7,15 @@ import { getCurrentUser, requireUser } from './auth';
 
 export const voicepackRoutes = new Hono<{ Bindings: Env }>();
 
+const MAX_UPLOAD_BYTES = 50 * 1024 * 1024; // 50 MB
+
 /** Build a voice pack from uploaded WAV clips */
 voicepackRoutes.post('/build', async (c) => {
+  const contentLength = parseInt(c.req.header('content-length') || '0');
+  if (contentLength > MAX_UPLOAD_BYTES) {
+    return c.json({ detail: 'Upload too large (max 50 MB)' }, 413);
+  }
+
   const body = await c.req.parseBody({ all: true });
 
   const name = String(body['name'] || '');
@@ -119,7 +126,14 @@ voicepackRoutes.post('/build', async (c) => {
 voicepackRoutes.get('/:buildId/download', async (c) => {
   const buildId = c.req.param('buildId');
 
-  const row = await c.env.DB.prepare('SELECT r2_key FROM packs WHERE id = ?').bind(buildId).first<{ r2_key: string }>();
+  // Restrict to unpublished builds created within the last 7 days.
+  // This prevents indefinite exposure of builds and stops the endpoint
+  // from serving published packs (which have their own download route).
+  const row = await c.env.DB.prepare(
+    `SELECT r2_key FROM packs
+     WHERE id = ? AND published = 0
+       AND created_at > datetime('now', '-7 days')`,
+  ).bind(buildId).first<{ r2_key: string }>();
   if (!row) return c.json({ detail: 'Voice pack not found' }, 404);
 
   const obj = await c.env.PACKS_BUCKET.get(row.r2_key);
@@ -195,9 +209,11 @@ voicepackRoutes.get('/', async (c) => {
 
   const offset = Math.max(0, parseInt(c.req.query('offset') || '0') || 0);
   const limit = Math.min(100, Math.max(1, parseInt(c.req.query('limit') || '20') || 20));
-  const sort = c.req.query('sort') || 'newest';
+  const sortRaw = c.req.query('sort') || 'newest';
+  const sort = sortRaw === 'top' ? 'top' : 'newest';
   const q = (c.req.query('q') || '').slice(0, 100);
-  const gender = c.req.query('gender') || 'all';
+  const genderRaw = c.req.query('gender') || 'all';
+  const gender = ['male', 'female', 'all'].includes(genderRaw) ? genderRaw : 'all';
   const minScore = parseInt(c.req.query('minScore') || '0') || 0;
   const hasRecommended = c.req.query('hasRecommended') === 'true';
   const authorFilter = c.req.query('author') || '';


### PR DESCRIPTION
- Drop tauri-plugin-shell from Cargo.toml, lib.rs init, and capabilities.
  The shell plugin was never called; all open() dialogs use plugin-dialog.
  Its presence caused AV heuristics to flag the binary as capable of
  spawning arbitrary processes.
- Remove dialog:allow-save capability — no save-dialog calls exist.
- Replace null CSP with a restrictive policy: script-src 'self', no
  unsafe-eval, connect-src limited to self + Tauri IPC origins.

https://claude.ai/code/session_01HNFF9QqSZHXJpk7ALeR9KN