### PR TITLE
Fix stale vote state after auth transitions

### DIFF
--- a/client/src/components/library/LibraryBrowser.tsx
+++ b/client/src/components/library/LibraryBrowser.tsx
@@ -29,6 +29,7 @@ export function LibraryBrowser() {
 
   // Infinite scroll sentinel
   const sentinelRef = useRef<HTMLDivElement>(null);
+  const lastUserIdRef = useRef<string | null>(user?.steamId ?? null);
 
   useEffect(() => {
     const sentinel = sentinelRef.current;
@@ -46,6 +47,13 @@ export function LibraryBrowser() {
     observer.observe(sentinel);
     return () => observer.disconnect();
   }, [loadMore]);
+
+  useEffect(() => {
+    const currentUserId = user?.steamId ?? null;
+    if (lastUserIdRef.current === currentUserId) return;
+    lastUserIdRef.current = currentUserId;
+    refresh();
+  }, [user?.steamId, refresh]);
 
   const handleDelete = useCallback(
     async (packId: string) => {

--- a/client/src/components/library/useLibraryPacks.ts
+++ b/client/src/components/library/useLibraryPacks.ts
@@ -136,7 +136,11 @@ export function useLibraryPacks() {
     fetchPacks(filters, 0, false);
   }, [filters, fetchPacks]);
 
-  /** Optimistic vote update — mutates local state, fires API, reverts on error */
+  /**
+   * Optimistic vote update — mutates local state, fires API, reverts on error.
+   * TODO: Track in-flight vote requests per pack and disable repeat clicks until resolve.
+   * This would prevent accidental double-submit jitter on slow connections.
+   */
   const updatePackVote = useCallback(async (packId: string, vote: 1 | -1 | 0) => {
     // Snapshot for rollback
     const prevPacks = packs;


### PR DESCRIPTION
## Summary
- refresh library data when auth identity changes (anon <-> logged-in)
- ensures userVote indicators are corrected immediately after login/logout without requiring a manual vote action
- add a TODO in optimistic voting path for per-pack in-flight vote locking to reduce double-click jitter

## Validation
- npm --prefix client run lint
- npm --prefix client run build