### PR TITLE
Add URL routes for create, browse, and instructions

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.1",
       "dependencies": {
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "react-router-dom": "^6.30.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.21.0",
@@ -1225,6 +1226,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
+      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -4050,6 +4060,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
+      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
+      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.2",
+        "react-router": "6.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/read-cache": {

--- a/client/package.json
+++ b/client/package.json
@@ -14,7 +14,8 @@
   },
   "dependencies": {
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "react-router-dom": "^6.30.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,15 +1,15 @@
-import { useState } from 'react';
+import { NavLink, Navigate, Route, Routes } from 'react-router-dom';
 import { PackBuilder } from '@/components/pack-builder/PackBuilder';
 import { LibraryBrowser } from '@/components/library/LibraryBrowser';
 import { InstructionsPage } from '@/components/instructions/InstructionsPage';
 import { useAuth } from '@/hooks/useAuth';
 
-type Page = 'create' | 'browse' | 'instructions';
-
-// TODO: Replace simple state-based routing with a proper router (e.g., react-router-dom) to support deep linking and browser history.
 function App() {
-  const [page, setPage] = useState<Page>('create');
   const { user, loading, login, logout } = useAuth();
+  const navLinkClass = ({ isActive }: { isActive: boolean }) =>
+    `font-medium text-sm transition-colors ${
+      isActive ? 'text-mew-accent' : 'text-mew-muted hover:text-mew-text'
+    }`;
 
   return (
     <div className="min-h-screen bg-mew-bg">
@@ -25,27 +25,15 @@ function App() {
           </div>
           <div className="flex items-center gap-4">
             <nav className="flex gap-4">
-              <button
-                onClick={() => setPage('create')}
-                className={`font-medium text-sm transition-colors ${page === 'create' ? 'text-mew-accent' : 'text-mew-muted hover:text-mew-text'
-                  }`}
-              >
+              <NavLink to="/create" className={navLinkClass}>
                 Create
-              </button>
-              <button
-                onClick={() => setPage('browse')}
-                className={`font-medium text-sm transition-colors ${page === 'browse' ? 'text-mew-accent' : 'text-mew-muted hover:text-mew-text'
-                  }`}
-              >
+              </NavLink>
+              <NavLink to="/browse" className={navLinkClass}>
                 Browse Packs
-              </button>
-              <button
-                onClick={() => setPage('instructions')}
-                className={`font-medium text-sm transition-colors ${page === 'instructions' ? 'text-mew-accent' : 'text-mew-muted hover:text-mew-text'
-                  }`}
-              >
+              </NavLink>
+              <NavLink to="/instructions" className={navLinkClass}>
                 Instructions
-              </button>
+              </NavLink>
             </nav>
 
             <div className="border-l border-mew-highlight/30 pl-4">
@@ -90,9 +78,14 @@ function App() {
 
       {/* Main content */}
       <main className="px-4 py-8">
-        {page === 'create' && <PackBuilder />}
-        {page === 'browse' && <LibraryBrowser />}
-        {page === 'instructions' && <InstructionsPage />}
+        {/* TODO: Split route-level bundles so /browse can load without create-page recorder code. */}
+        <Routes>
+          <Route path="/" element={<Navigate to="/create" replace />} />
+          <Route path="/create" element={<PackBuilder />} />
+          <Route path="/browse" element={<LibraryBrowser />} />
+          <Route path="/instructions" element={<InstructionsPage />} />
+          <Route path="*" element={<Navigate to="/create" replace />} />
+        </Routes>
       </main>
 
       {/* Footer */}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,5 +1,6 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App'
 import { AuthProvider } from '@/contexts/AuthContext'
@@ -7,7 +8,9 @@ import { AuthProvider } from '@/contexts/AuthContext'
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <AuthProvider>
-      <App />
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
     </AuthProvider>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- replace state-only client page switching with route-based navigation
- add browser paths for /create, /browse, and /instructions
- keep existing app shell/auth header and add redirect handling for / and unknown paths
- add a TODO for future route-level code splitting

## Validation
- npm --prefix client run lint
- npm --prefix client run build