### PR TITLE
Add desktop community library browse and install panel

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -1422,8 +1422,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1744,6 +1746,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2203,6 +2206,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "lzma-rs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2277,9 +2286,10 @@ dependencies = [
 
 [[package]]
 name = "mewvoice-desktop"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "log",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tauri",
@@ -3131,6 +3141,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3177,6 +3242,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3197,6 +3272,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3212,6 +3297,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3323,6 +3417,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
 dependencies = [
  "bytecheck",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3448,6 +3580,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3501,6 +3639,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -3547,6 +3686,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -3773,6 +3918,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -4183,7 +4340,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "serde_repr",
@@ -4394,7 +4551,7 @@ dependencies = [
  "minisign-verify",
  "osakit",
  "percent-encoding",
- "reqwest",
+ "reqwest 0.13.2",
  "rustls",
  "semver",
  "serde",
@@ -5218,6 +5375,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webkit2gtk"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5266,6 +5433,15 @@ name = "webpki-root-certs"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -30,3 +30,4 @@ zip = "2"
 uuid = { version = "1", features = ["v4"] }
 tauri-plugin-updater = "2.10.0"
 tauri-plugin-process = "2.3.1"
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }

--- a/desktop/src-tauri/src/commands/mod.rs
+++ b/desktop/src-tauri/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod catgen;
 pub mod install;
 pub mod paths;
+pub mod remote;
 pub mod scan;
 pub mod state;

--- a/desktop/src-tauri/src/commands/remote.rs
+++ b/desktop/src-tauri/src/commands/remote.rs
@@ -1,0 +1,86 @@
+use std::fs;
+
+const REMOTE_API_BASE: &str = "https://mewvoice.com/api";
+
+#[tauri::command]
+pub async fn list_remote_packs(
+    sort: String,
+    q: String,
+    gender: String,
+    offset: u32,
+    limit: u32,
+) -> Result<String, String> {
+    let normalized_sort = if sort == "top" { "top" } else { "newest" };
+    let normalized_gender = match gender.as_str() {
+        "male" => "male",
+        "female" => "female",
+        _ => "all",
+    };
+    let clamped_limit = limit.clamp(1, 100);
+    let clamped_q = q.trim().chars().take(100).collect::<String>();
+
+    let mut url = reqwest::Url::parse(&format!("{REMOTE_API_BASE}/voicepacks"))
+        .map_err(|e| format!("Invalid remote URL: {e}"))?;
+    {
+        let mut query = url.query_pairs_mut();
+        query.append_pair("offset", &offset.to_string());
+        query.append_pair("limit", &clamped_limit.to_string());
+        query.append_pair("sort", normalized_sort);
+        if !clamped_q.is_empty() {
+            query.append_pair("q", &clamped_q);
+        }
+        if normalized_gender != "all" {
+            query.append_pair("gender", normalized_gender);
+        }
+    }
+
+    let response = reqwest::get(url)
+        .await
+        .map_err(|e| format!("Failed to load community library: {e}"))?;
+    let status = response.status();
+    let body = response
+        .text()
+        .await
+        .map_err(|e| format!("Failed to read community library response: {e}"))?;
+    if !status.is_success() {
+        return Err(format!("Failed to load community library (HTTP {status})"));
+    }
+
+    Ok(body)
+}
+
+#[tauri::command]
+pub async fn download_and_install_pack(pack_id: String, mod_root: String) -> Result<String, String> {
+    let trimmed_pack_id = pack_id.trim();
+    if trimmed_pack_id.is_empty() {
+        return Err("Pack ID is required".to_string());
+    }
+
+    let url = format!("{REMOTE_API_BASE}/voicepacks/{trimmed_pack_id}/download-published");
+    let response = reqwest::get(&url)
+        .await
+        .map_err(|e| format!("Failed to download voice pack: {e}"))?;
+    let status = response.status();
+    if !status.is_success() {
+        return Err(format!("Failed to download voice pack (HTTP {status})"));
+    }
+
+    let bytes = response
+        .bytes()
+        .await
+        .map_err(|e| format!("Failed to read downloaded pack data: {e}"))?;
+
+    let temp_zip_path = std::env::temp_dir().join(format!(
+        "mewvoice_{trimmed_pack_id}_{}.zip",
+        uuid::Uuid::new_v4()
+    ));
+    fs::write(&temp_zip_path, &bytes).map_err(|e| format!("Failed to write temporary ZIP: {e}"))?;
+
+    // TODO: Verify a published checksum/signature once the API exposes one.
+    let install_result = super::install::install_pack(
+        temp_zip_path.to_string_lossy().to_string(),
+        mod_root,
+    );
+    let _ = fs::remove_file(&temp_zip_path);
+    install_result
+}

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -26,6 +26,8 @@ pub fn run() {
             commands::catgen::write_voice_patch,
             commands::install::install_pack,
             commands::install::uninstall_pack,
+            commands::remote::list_remote_packs,
+            commands::remote::download_and_install_pack,
             commands::scan::scan_installed_packs,
         ])
         .run(tauri::generate_context!())

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import Shell from '@/components/layout/Shell';
 import type { Panel } from '@/components/layout/Sidebar';
 import InstalledPacksPanel from '@/components/panels/InstalledPacksPanel';
+import CommunityLibraryPanel from '@/components/panels/CommunityLibraryPanel';
 import BasePacksPanel from '@/components/panels/BasePacksPanel';
 import VoiceRegistrationPanel from '@/components/panels/VoiceRegistrationPanel';
 import SettingsPanel from '@/components/panels/SettingsPanel';
@@ -55,6 +56,14 @@ function App() {
           onUninstall={app.uninstallPack}
           onScan={scanPacks}
           patchDirty={showDirty}
+        />
+      )}
+      {activePanel === 'library' && (
+        <CommunityLibraryPanel
+          modRoot={state.mewtatorModRoot}
+          installedPackIds={state.packs.map((pack) => pack.id)}
+          onInstallPack={app.installPublishedPack}
+          onOpenSettings={() => setActivePanel('settings')}
         />
       )}
       {activePanel === 'base-packs' && (

--- a/desktop/src/components/layout/Sidebar.tsx
+++ b/desktop/src/components/layout/Sidebar.tsx
@@ -1,4 +1,4 @@
-type Panel = 'packs' | 'base-packs' | 'registration' | 'settings';
+type Panel = 'packs' | 'library' | 'base-packs' | 'registration' | 'settings';
 
 interface SidebarProps {
   activePanel: Panel;
@@ -8,6 +8,7 @@ interface SidebarProps {
 
 const NAV_ITEMS: { id: Panel; label: string; icon: string }[] = [
   { id: 'packs', label: 'Installed Packs', icon: '\u{1F4E6}' },
+  { id: 'library', label: 'Browse Library', icon: '\u{1F50D}' },
   { id: 'base-packs', label: 'Base Game Voices', icon: '\u{1F3AE}' },
   { id: 'registration', label: 'Voice Patch', icon: '\u{1F3AF}' },
   { id: 'settings', label: 'Settings', icon: '\u{2699}\u{FE0F}' },

--- a/desktop/src/components/panels/CommunityLibraryPanel.tsx
+++ b/desktop/src/components/panels/CommunityLibraryPanel.tsx
@@ -1,0 +1,358 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { CommunityLibraryFilters, CommunityPackMeta } from '@/types/library';
+import { getCommunityPreviewUrl, listCommunityPacks } from '@/lib/commands';
+
+interface CommunityLibraryPanelProps {
+  modRoot: string | null;
+  installedPackIds: string[];
+  onInstallPack: (packId: string) => Promise<void>;
+  onOpenSettings: () => void;
+}
+
+const PAGE_SIZE = 20;
+const SEARCH_DEBOUNCE_MS = 250;
+// TODO: Move this panel to cursor pagination + virtualization when the library grows further.
+
+const DEFAULT_FILTERS: CommunityLibraryFilters = {
+  sort: 'newest',
+  q: '',
+  gender: 'all',
+};
+
+export default function CommunityLibraryPanel({
+  modRoot,
+  installedPackIds,
+  onInstallPack,
+  onOpenSettings,
+}: CommunityLibraryPanelProps) {
+  const [filters, setFilters] = useState<CommunityLibraryFilters>(DEFAULT_FILTERS);
+  const [packs, setPacks] = useState<CommunityPackMeta[]>([]);
+  const [total, setTotal] = useState(0);
+  const [hasMore, setHasMore] = useState(false);
+  const [initialLoading, setInitialLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [installingPackIds, setInstallingPackIds] = useState<string[]>([]);
+  const [playingPackId, setPlayingPackId] = useState<string | null>(null);
+
+  const hasLoadedRef = useRef(false);
+  const fetchIdRef = useRef(0);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const searchQueryRef = useRef(filters.q);
+  const nonSearchFiltersRef = useRef({
+    sort: filters.sort,
+    gender: filters.gender,
+  });
+
+  const installedSet = useMemo(() => new Set(installedPackIds), [installedPackIds]);
+
+  const fetchPacks = useCallback(
+    async (nextFilters: CommunityLibraryFilters, offset: number, append: boolean) => {
+      const fetchId = ++fetchIdRef.current;
+
+      if (append) {
+        setLoadingMore(true);
+      } else if (!hasLoadedRef.current) {
+        setInitialLoading(true);
+      } else {
+        setRefreshing(true);
+      }
+      setError(null);
+
+      try {
+        const result = await listCommunityPacks(nextFilters, offset, PAGE_SIZE);
+        if (fetchId !== fetchIdRef.current) return;
+
+        if (append) {
+          setPacks((current) => [...current, ...result.packs]);
+        } else {
+          setPacks(result.packs);
+        }
+        setTotal(result.total);
+        setHasMore(result.hasMore);
+        hasLoadedRef.current = true;
+      } catch {
+        if (fetchId !== fetchIdRef.current) return;
+        setError('Failed to load community packs.');
+      } finally {
+        if (fetchId === fetchIdRef.current) {
+          setInitialLoading(false);
+          setRefreshing(false);
+          setLoadingMore(false);
+        }
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    searchQueryRef.current = filters.q;
+  }, [filters.q]);
+
+  useEffect(() => {
+    nonSearchFiltersRef.current = {
+      sort: filters.sort,
+      gender: filters.gender,
+    };
+  }, [filters.sort, filters.gender]);
+
+  useEffect(() => {
+    fetchPacks(
+      {
+        ...nonSearchFiltersRef.current,
+        q: searchQueryRef.current,
+      },
+      0,
+      false,
+    );
+  }, [fetchPacks, filters.sort, filters.gender]);
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      fetchPacks(
+        {
+          ...nonSearchFiltersRef.current,
+          q: searchQueryRef.current,
+        },
+        0,
+        false,
+      );
+    }, SEARCH_DEBOUNCE_MS);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [fetchPacks, filters.q]);
+
+  useEffect(() => {
+    return () => {
+      if (audioRef.current) {
+        audioRef.current.pause();
+        audioRef.current = null;
+      }
+    };
+  }, []);
+
+  const handleLoadMore = useCallback(() => {
+    if (!hasMore || loadingMore) return;
+    fetchPacks(filters, packs.length, true);
+  }, [hasMore, loadingMore, fetchPacks, filters, packs.length]);
+
+  const refresh = useCallback(() => {
+    fetchPacks(filters, 0, false);
+  }, [fetchPacks, filters]);
+
+  const handleInstall = useCallback(
+    async (packId: string) => {
+      // TODO: Surface per-pack download progress from Tauri for better install feedback.
+      setInstallingPackIds((current) =>
+        current.includes(packId) ? current : [...current, packId],
+      );
+      try {
+        await onInstallPack(packId);
+      } finally {
+        setInstallingPackIds((current) => current.filter((id) => id !== packId));
+      }
+    },
+    [onInstallPack],
+  );
+
+  const handlePreview = useCallback((packId: string) => {
+    if (playingPackId === packId) {
+      if (audioRef.current) {
+        audioRef.current.pause();
+        audioRef.current = null;
+      }
+      setPlayingPackId(null);
+      return;
+    }
+
+    if (audioRef.current) {
+      audioRef.current.pause();
+      audioRef.current = null;
+    }
+
+    const url = getCommunityPreviewUrl(packId);
+    const withBust = `${url}${url.includes('?') ? '&' : '?'}_t=${Date.now()}`;
+    const audio = new Audio(withBust);
+    audioRef.current = audio;
+    setPlayingPackId(packId);
+
+    audio.play().catch(() => {
+      setPlayingPackId(null);
+      audioRef.current = null;
+    });
+    audio.onended = () => {
+      setPlayingPackId(null);
+      audioRef.current = null;
+    };
+  }, [playingPackId]);
+
+  return (
+    <div>
+      <div className="flex items-start justify-between mb-6 gap-4">
+        <div>
+          <h2 className="text-xl font-semibold">Community Library</h2>
+          <p className="text-sm text-mew-muted mt-1">
+            Browse public MewVoice packs and install them directly.
+          </p>
+        </div>
+      </div>
+
+      {!modRoot && (
+        <div className="mb-4 rounded-lg border border-amber-500/40 bg-amber-500/10 p-3 text-sm">
+          <p className="text-amber-200">
+            Set your Mewtator mod folder in Settings before installing.
+          </p>
+          <button
+            onClick={onOpenSettings}
+            className="mt-2 text-xs text-amber-100 underline hover:text-white"
+          >
+            Open Settings
+          </button>
+        </div>
+      )}
+
+      <div className="flex flex-wrap gap-2 mb-4">
+        <input
+          type="text"
+          value={filters.q}
+          onChange={(e) => setFilters((current) => ({ ...current, q: e.target.value }))}
+          placeholder="Search by name, description, or author..."
+          className="min-w-[220px] flex-1 px-3 py-1.5 text-sm bg-mew-bg border border-mew-highlight/50 rounded"
+        />
+        <select
+          value={filters.gender}
+          onChange={(e) =>
+            setFilters((current) => ({
+              ...current,
+              gender: e.target.value as CommunityLibraryFilters['gender'],
+            }))
+          }
+          className="px-3 py-1.5 text-sm bg-mew-surface border border-mew-highlight/50 rounded"
+        >
+          <option value="all">All genders</option>
+          <option value="male">Male</option>
+          <option value="female">Female</option>
+        </select>
+        <select
+          value={filters.sort}
+          onChange={(e) =>
+            setFilters((current) => ({
+              ...current,
+              sort: e.target.value as CommunityLibraryFilters['sort'],
+            }))
+          }
+          className="px-3 py-1.5 text-sm bg-mew-surface border border-mew-highlight/50 rounded"
+        >
+          <option value="newest">Newest</option>
+          <option value="top">Top score</option>
+        </select>
+      </div>
+
+      {initialLoading ? (
+        <div className="text-center py-16 text-mew-muted">Loading community packs...</div>
+      ) : error ? (
+        <div className="text-center py-16">
+          <p className="text-red-300 mb-3">{error}</p>
+          <button
+            onClick={refresh}
+            className="px-3 py-1.5 text-sm bg-mew-accent text-white rounded hover:bg-mew-accent/80"
+          >
+            Retry
+          </button>
+        </div>
+      ) : (
+        <>
+          {refreshing && (
+            <p className="text-xs text-mew-muted mb-2">Refreshing...</p>
+          )}
+
+          {packs.length === 0 ? (
+            <div className="text-center py-12 border border-dashed border-mew-highlight/30 rounded-lg">
+              <p className="text-mew-muted">No packs found for this filter.</p>
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
+              {packs.map((pack) => {
+                const totalClips = Object.values(pack.clipCounts).reduce((sum, n) => sum + n, 0);
+                const isInstalling = installingPackIds.includes(pack.id);
+                const isInstalled = installedSet.has(pack.id);
+                const isPlaying = playingPackId === pack.id;
+
+                return (
+                  <div key={pack.id} className="rounded-lg border border-mew-highlight/30 bg-mew-surface p-4">
+                    <div className="flex items-start justify-between gap-2">
+                      <div className="min-w-0">
+                        <h3 className="font-medium truncate">{pack.name}</h3>
+                        <p className="text-xs text-mew-muted truncate">
+                          by {pack.steamName || pack.author || 'Anonymous'}
+                        </p>
+                      </div>
+                      <button
+                        onClick={() => handlePreview(pack.id)}
+                        className={`px-2 py-1 text-xs rounded border transition-colors ${
+                          isPlaying
+                            ? 'bg-mew-accent text-white border-mew-accent'
+                            : 'border-mew-highlight/50 text-mew-muted hover:text-mew-text hover:bg-mew-highlight/20'
+                        }`}
+                      >
+                        {isPlaying ? 'Stop' : 'Preview'}
+                      </button>
+                    </div>
+
+                    {pack.description && (
+                      <p className="text-sm text-mew-muted mt-2 line-clamp-2">
+                        {pack.description}
+                      </p>
+                    )}
+
+                    <div className="mt-3 text-xs text-mew-muted flex flex-wrap gap-x-3 gap-y-1">
+                      <span>{totalClips} clips</span>
+                      <span>Score: {pack.score}</span>
+                      <span>
+                        {pack.downloads} download{pack.downloads === 1 ? '' : 's'}
+                      </span>
+                      {isInstalled && (
+                        <span className="text-mew-sage">Installed</span>
+                      )}
+                    </div>
+
+                    <div className="mt-3 flex items-center justify-end">
+                      <button
+                        onClick={() => handleInstall(pack.id)}
+                        disabled={!modRoot || isInstalling}
+                        className={`px-3 py-1.5 text-sm rounded transition-colors ${
+                          !modRoot || isInstalling
+                            ? 'bg-mew-surface border border-mew-highlight/50 text-mew-muted'
+                            : 'bg-mew-accent text-white hover:bg-mew-accent/80'
+                        }`}
+                      >
+                        {isInstalling ? 'Installing...' : isInstalled ? 'Reinstall' : 'Download + Install'}
+                      </button>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          <div className="mt-4 flex items-center justify-between text-sm">
+            <p className="text-mew-muted">{total} total pack{total === 1 ? '' : 's'}</p>
+            {hasMore && (
+              <button
+                onClick={handleLoadMore}
+                disabled={loadingMore}
+                className="px-3 py-1.5 rounded border border-mew-highlight/50 hover:bg-mew-highlight/20 disabled:opacity-60"
+              >
+                {loadingMore ? 'Loading...' : 'Load more'}
+              </button>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/desktop/src/components/panels/InstalledPacksPanel.tsx
+++ b/desktop/src/components/panels/InstalledPacksPanel.tsx
@@ -73,7 +73,6 @@ export default function InstalledPacksPanel({
       }
     } catch (e) {
       console.error('Failed to open MewVoice:', e);
-      // TODO(stretch): Add an in-app library/download page so desktop users can browse voice packs without leaving the app.
       await showManualOpenFallback();
     }
   };

--- a/desktop/src/hooks/useAppState.ts
+++ b/desktop/src/hooks/useAppState.ts
@@ -131,6 +131,23 @@ export function useAppState() {
     [state.mewtatorModRoot, addPack],
   );
 
+  const installPublishedPack = useCallback(
+    async (packId: string) => {
+      if (!state.mewtatorModRoot) {
+        setError('Mewtator mod root not configured');
+        return;
+      }
+      try {
+        const pack = await cmd.installPublishedPack(packId, state.mewtatorModRoot);
+        addPack(pack);
+        setError(null);
+      } catch (e) {
+        setError(String(e));
+      }
+    },
+    [state.mewtatorModRoot, addPack],
+  );
+
   const uninstallPack = useCallback(
     async (packId: string) => {
       if (!state.mewtatorModRoot) return;
@@ -185,6 +202,7 @@ export function useAppState() {
     toggleMuteBasePack,
     regeneratePatch,
     importZip,
+    installPublishedPack,
     uninstallPack,
     scanPacks,
     clearError: () => setError(null),

--- a/desktop/src/lib/commands.ts
+++ b/desktop/src/lib/commands.ts
@@ -1,5 +1,6 @@
 import type { AppState, InstalledVoicePack } from '@/types/manager';
 import { createDefaultState } from '@/types/manager';
+import type { CommunityLibraryFilters, CommunityLibraryResult } from '@/types/library';
 
 /**
  * Check if we're running inside the Tauri webview (vs. a plain browser).
@@ -8,6 +9,9 @@ import { createDefaultState } from '@/types/manager';
 function isTauri(): boolean {
   return '__TAURI_INTERNALS__' in window;
 }
+
+const WEB_API_BASE = '/api';
+const REMOTE_API_BASE = 'https://mewvoice.com/api';
 
 /**
  * Lazy-import invoke to avoid crashing when Tauri isn't available.
@@ -88,5 +92,52 @@ export async function scanInstalledPacks(
 ): Promise<InstalledVoicePack[]> {
   if (!isTauri()) return [];
   const json = await tauriInvoke<string>('scan_installed_packs', { modRoot });
+  return JSON.parse(json);
+}
+
+// ── Community library (desktop-safe path via Tauri invoke) ──
+
+function buildLibraryQuery(filters: CommunityLibraryFilters, offset: number, limit: number): string {
+  const params = new URLSearchParams();
+  params.set('offset', String(offset));
+  params.set('limit', String(limit));
+  params.set('sort', filters.sort);
+  if (filters.q) params.set('q', filters.q);
+  if (filters.gender !== 'all') params.set('gender', filters.gender);
+  return params.toString();
+}
+
+export async function listCommunityPacks(
+  filters: CommunityLibraryFilters,
+  offset = 0,
+  limit = 20,
+): Promise<CommunityLibraryResult> {
+  if (isTauri()) {
+    const json = await tauriInvoke<string>('list_remote_packs', {
+      sort: filters.sort,
+      q: filters.q,
+      gender: filters.gender,
+      offset,
+      limit,
+    });
+    return JSON.parse(json);
+  }
+
+  const query = buildLibraryQuery(filters, offset, limit);
+  const response = await fetch(`${WEB_API_BASE}/voicepacks?${query}`);
+  if (!response.ok) throw new Error('Failed to load community packs');
+  return response.json();
+}
+
+export function getCommunityPreviewUrl(packId: string): string {
+  const apiBase = isTauri() ? REMOTE_API_BASE : WEB_API_BASE;
+  return `${apiBase}/voicepacks/${packId}/preview`;
+}
+
+export async function installPublishedPack(packId: string, modRoot: string): Promise<InstalledVoicePack> {
+  if (!isTauri()) {
+    throw new Error('Published pack installation requires the desktop app');
+  }
+  const json = await tauriInvoke<string>('download_and_install_pack', { packId, modRoot });
   return JSON.parse(json);
 }

--- a/desktop/src/types/library.ts
+++ b/desktop/src/types/library.ts
@@ -1,0 +1,24 @@
+export interface CommunityPackMeta {
+  id: string;
+  name: string;
+  author: string;
+  gender: 'male' | 'female';
+  description: string;
+  clipCounts: Record<string, number>;
+  createdAt: string;
+  downloads: number;
+  score: number;
+  steamName?: string;
+}
+
+export interface CommunityLibraryFilters {
+  sort: 'newest' | 'top';
+  q: string;
+  gender: 'all' | 'male' | 'female';
+}
+
+export interface CommunityLibraryResult {
+  packs: CommunityPackMeta[];
+  total: number;
+  hasMore: boolean;
+}


### PR DESCRIPTION
## Summary
- add a new desktop sidebar page for browsing community packs in-app
- add read-only library UI with search, gender filter, sort, preview, and load-more
- install packs directly into the configured mod folder (no Steam login, no voting, no upload/record)
- route desktop library calls through new Tauri Rust commands to avoid webview CORS issues
- add TODOs for keyset pagination/virtualization, install progress feedback, and remote checksum verification

## Validation
- npm --prefix desktop run lint
- npm --prefix desktop run test
- npm --prefix desktop run build:web
- cargo check --manifest-path desktop/src-tauri/Cargo.toml