### PR TITLE
Normalize line endings and pin npm toolchain

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,36 @@
+# Default normalization for text files.
+* text=auto
+
+# Force LF for source/config/lock files to prevent CRLF churn across platforms.
+*.c text eol=lf
+*.h text eol=lf
+*.css text eol=lf
+*.html text eol=lf
+*.js text eol=lf
+*.jsx text eol=lf
+*.json text eol=lf
+*.jsonc text eol=lf
+*.lock text eol=lf
+*.md text eol=lf
+*.rs text eol=lf
+*.sql text eol=lf
+*.toml text eol=lf
+*.ts text eol=lf
+*.tsx text eol=lf
+*.txt text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf
+
+# Keep Windows shell scripts in CRLF where expected.
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf
+
+# Treat common assets as binary.
+*.ico binary
+*.jpg binary
+*.jpeg binary
+*.png binary
+*.webm binary
+*.wav binary
+*.zip binary

--- a/client/package.json
+++ b/client/package.json
@@ -2,6 +2,7 @@
   "name": "mewgenics-voice-pack",
   "private": true,
   "version": "0.1.1",
+  "packageManager": "npm@11.11.0",
   "description": "Community voice pack creator for Mewgenics",
   "type": "module",
   "scripts": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -2,6 +2,7 @@
   "name": "desktop",
   "private": true,
   "version": "0.2.4",
+  "packageManager": "npm@11.11.0",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,7 @@
 {
   "name": "mewvoice-api",
   "version": "1.0.0",
+  "packageManager": "npm@11.11.0",
   "private": true,
   "scripts": {
     "dev": "wrangler dev --local --port 8787",


### PR DESCRIPTION
## Summary
- add .gitattributes to normalize text files and force LF for source/config/lock files
- keep Windows script files (.bat, .cmd, .ps1) in CRLF
- pin npm version with packageManager: npm@11.11.0 in client, desktop, and worker package manifests

## Why
- reduces noisy CRLF/LF-only diffs in files like Cargo.toml and lockfiles
- keeps lockfile generation behavior consistent across contributors