### PR TITLE
Harden dependency CI and group Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,30 +2,85 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: /
+    labels:
+      - dependencies
+    open-pull-requests-limit: 10
+    rebase-strategy: auto
+    groups:
+      github-actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
     schedule:
       interval: weekly
       day: monday
 
   - package-ecosystem: npm
     directory: /client
+    labels:
+      - dependencies
+    open-pull-requests-limit: 10
+    rebase-strategy: auto
+    groups:
+      client-npm-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
     schedule:
       interval: weekly
       day: monday
 
   - package-ecosystem: npm
     directory: /desktop
+    labels:
+      - dependencies
+    open-pull-requests-limit: 10
+    rebase-strategy: auto
+    groups:
+      desktop-npm-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
     schedule:
       interval: weekly
       day: monday
 
   - package-ecosystem: npm
     directory: /worker
+    labels:
+      - dependencies
+    open-pull-requests-limit: 10
+    rebase-strategy: auto
+    groups:
+      worker-npm-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
     schedule:
       interval: weekly
       day: monday
 
   - package-ecosystem: cargo
     directory: /desktop/src-tauri
+    labels:
+      - dependencies
+    open-pull-requests-limit: 10
+    rebase-strategy: auto
+    groups:
+      desktop-cargo-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
     schedule:
       interval: weekly
       day: monday

--- a/.github/workflows/dependency-validation.yml
+++ b/.github/workflows/dependency-validation.yml
@@ -1,0 +1,95 @@
+name: dependency-validation
+
+on:
+  pull_request:
+    paths:
+      - "client/package.json"
+      - "client/package-lock.json"
+      - "desktop/package.json"
+      - "desktop/package-lock.json"
+      - "desktop/src-tauri/Cargo.toml"
+      - "desktop/src-tauri/Cargo.lock"
+      - "worker/package.json"
+      - "worker/package-lock.json"
+      - ".github/workflows/**"
+  workflow_dispatch:
+
+concurrency:
+  group: dependency-validation-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  client:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: client
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: client/package-lock.json
+      - name: Install
+        run: npm ci
+      - name: Lint
+        run: npm run lint
+      - name: Build
+        run: npm run build
+      - name: Audit High/Critical
+        run: npm audit --audit-level=high
+
+  desktop:
+    runs-on: windows-latest
+    defaults:
+      run:
+        working-directory: desktop
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: desktop/package-lock.json
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install
+        run: npm ci
+      - name: Lint
+        run: npm run lint
+      - name: Test
+        run: npm run test
+      - name: Build Web
+        run: npm run build:web
+      - name: Cargo Check
+        run: cargo check --manifest-path src-tauri/Cargo.toml
+      - name: Audit High/Critical
+        run: npm audit --audit-level=high
+
+  worker:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: worker
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: worker/package-lock.json
+      - name: Install
+        run: npm ci
+      - name: Lint
+        run: npm run lint
+      - name: Typecheck
+        run: npm run typecheck
+      - name: Audit High/Critical
+        run: npm audit --audit-level=high


### PR DESCRIPTION
## Summary
- add a dedicated dependency-validation workflow for dependency/workflow changes
- validate client/desktop/worker install, lint, build/test, audit, and desktop cargo check
- add Dependabot grouping for patch/minor updates per ecosystem
- add Dependabot labels/rebase/open PR limit to reduce merge conflicts

## Why
- prevent silent dependency regressions from landing
- reduce stale/conflicting Dependabot PR waves