### PR TITLE
Fix missing Tailwind styles after #39 merge

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,6 +1,6 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";
+
+@config "../tailwind.config.js";
 
 :root {
   --color-charcoal: #1C1917;        /* Page background — deep warm black */

--- a/client/stylelint.config.cjs
+++ b/client/stylelint.config.cjs
@@ -1,6 +1,8 @@
 module.exports = {
   extends: ['stylelint-config-standard'],
   rules: {
+    // Tailwind v4 documentation uses string import syntax: @import "tailwindcss";
+    'import-notation': null,
     'at-rule-no-unknown': [
       true,
       {


### PR DESCRIPTION
## Summary
- apply the post-#39 Tailwind v4 stylesheet fix on top of current dev
- switch client/src/index.css to Tailwind v4 import/config directives
- allow Tailwind v4 canonical import syntax in client/stylelint.config.cjs

## Validation
- cd client && npm run lint
- cd client && npm run build