### PR TITLE
Restore white borders on pack cards and UI panels

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -14,7 +14,7 @@ function App() {
   return (
     <div className="min-h-screen bg-mew-bg">
       {/* Header */}
-      <header className="border-b border-mew-highlight/30 bg-mew-surface/50 backdrop-blur-sm sticky top-0 z-50">
+      <header className="border-b border-mew-border/30 bg-mew-surface/50 backdrop-blur-sm sticky top-0 z-50">
         <div className="max-w-4xl mx-auto px-4 py-4 flex items-center justify-between">
           <div className="flex items-center gap-3">
             <span className="text-3xl">🐱</span>
@@ -36,7 +36,7 @@ function App() {
               </NavLink>
             </nav>
 
-            <div className="border-l border-mew-highlight/30 pl-4">
+            <div className="border-l border-mew-border/30 pl-4">
               {loading ? (
                 <div className="w-8 h-8 rounded-full bg-mew-highlight/30 animate-pulse" />
               ) : user ? (
@@ -45,7 +45,7 @@ function App() {
                     <img
                       src={user.avatarUrl}
                       alt={user.personaName}
-                      className="w-8 h-8 rounded-full border border-mew-highlight/50"
+                      className="w-8 h-8 rounded-full border border-mew-border/50"
                     />
                   ) : (
                     <div className="w-8 h-8 rounded-full bg-mew-highlight/50 flex items-center justify-center text-xs text-mew-text">
@@ -89,7 +89,7 @@ function App() {
       </main>
 
       {/* Footer */}
-      <footer className="border-t border-mew-highlight/20 py-6 mt-12">
+      <footer className="border-t border-mew-border/20 py-6 mt-12">
         <p className="text-center text-mew-muted text-sm">
           Community tool — not affiliated with Edmund McMillen or Tyler Glaiel.
           Voice packs are compatible with Mewtator for Mewgenics.

--- a/client/src/components/instructions/InstructionsPage.tsx
+++ b/client/src/components/instructions/InstructionsPage.tsx
@@ -10,7 +10,7 @@ export function InstructionsPage() {
   return (
     <div className="max-w-4xl mx-auto space-y-6">
       {/* What is this */}
-      <section className="bg-mew-surface rounded-xl p-6 border border-mew-highlight/30">
+      <section className="bg-mew-surface rounded-xl p-6 border border-mew-border/30">
         <h2 className="text-2xl font-bold mb-3">What is this?</h2>
         <p className="text-mew-muted leading-relaxed">
           MewVoice lets you make custom cat voices for{' '}
@@ -25,7 +25,7 @@ export function InstructionsPage() {
       </section>
 
       {/* How it works */}
-      <section className="bg-mew-surface rounded-xl p-6 border border-mew-highlight/30">
+      <section className="bg-mew-surface rounded-xl p-6 border border-mew-border/30">
         <h2 className="text-2xl font-bold mb-4">How it works</h2>
         <ol className="space-y-3 text-mew-muted list-decimal list-inside">
           <li>
@@ -64,7 +64,7 @@ export function InstructionsPage() {
       </section>
 
       {/* Voice actions */}
-      <section className="bg-mew-surface rounded-xl p-6 border border-mew-highlight/30">
+      <section className="bg-mew-surface rounded-xl p-6 border border-mew-border/30">
         <h2 className="text-2xl font-bold mb-2">Voice actions</h2>
         <p className="text-mew-muted text-sm mb-4">
           Based on all 186 built-in voice packs in the game files. Six actions
@@ -74,7 +74,7 @@ export function InstructionsPage() {
         <div className="overflow-x-auto">
           <table className="w-full text-sm">
             <thead>
-              <tr className="text-left text-mew-muted border-b border-mew-highlight/30">
+              <tr className="text-left text-mew-muted border-b border-mew-border/30">
                 <th className="pb-2 pr-4">Action</th>
                 <th className="pb-2 pr-4">Description</th>
                 <th className="pb-2 pr-4 text-center">Recommended</th>
@@ -89,7 +89,7 @@ export function InstructionsPage() {
                 return (
                   <tr
                     key={action}
-                    className="border-b border-mew-highlight/10 text-mew-muted"
+                    className="border-b border-mew-border/10 text-mew-muted"
                   >
                     <td className="py-2 pr-4 text-mew-text font-medium whitespace-nowrap">
                       {action}
@@ -119,7 +119,7 @@ export function InstructionsPage() {
       </section>
 
       {/* Audio format */}
-      <section className="bg-mew-surface rounded-xl p-6 border border-mew-highlight/30">
+      <section className="bg-mew-surface rounded-xl p-6 border border-mew-border/30">
         <h2 className="text-2xl font-bold mb-3">Audio format</h2>
         <p className="text-mew-muted text-sm mb-4">
           Record in any format your browser supports (usually WebM), or upload
@@ -155,7 +155,7 @@ export function InstructionsPage() {
       </section>
 
       {/* Recording tips */}
-      <section className="bg-mew-surface rounded-xl p-6 border border-mew-highlight/30">
+      <section className="bg-mew-surface rounded-xl p-6 border border-mew-border/30">
         <h2 className="text-2xl font-bold mb-3">Recording tips</h2>
         <ul className="space-y-2 text-mew-muted text-sm list-disc list-inside">
           <li>Keep clips short. Most are under 1.5 seconds.</li>
@@ -180,7 +180,7 @@ export function InstructionsPage() {
       </section>
 
       {/* Installation */}
-      <section className="bg-mew-surface rounded-xl p-6 border border-mew-highlight/30">
+      <section className="bg-mew-surface rounded-xl p-6 border border-mew-border/30">
         <h2 className="text-2xl font-bold mb-3">Installing voice packs</h2>
 
         <p className="text-mew-muted text-sm mb-4">

--- a/client/src/components/library/LibraryToolbar.tsx
+++ b/client/src/components/library/LibraryToolbar.tsx
@@ -12,7 +12,7 @@ export function LibraryToolbar({ filters, setFilters, total, isLoggedIn, userSte
   const isMyPacks = !!filters.author && filters.author === userSteamId;
 
   return (
-    <div className="bg-mew-surface rounded-xl p-4 border border-mew-highlight/30 mb-6 space-y-3">
+    <div className="bg-mew-surface rounded-xl p-4 border border-mew-border/30 mb-6 space-y-3">
       {/* Top row: Search + Sort */}
       <div className="flex flex-col sm:flex-row gap-3">
         {/* Search */}
@@ -26,12 +26,12 @@ export function LibraryToolbar({ filters, setFilters, total, isLoggedIn, userSte
             onChange={(e) => setFilters({ q: e.target.value })}
             placeholder="Search packs..."
             maxLength={100}
-            className="w-full bg-mew-bg border border-mew-highlight/50 rounded-lg pl-9 pr-4 py-2 text-mew-text placeholder:text-mew-muted/50 focus:outline-none focus:border-mew-accent text-sm"
+            className="w-full bg-mew-bg border border-mew-border/50 rounded-lg pl-9 pr-4 py-2 text-mew-text placeholder:text-mew-muted/50 focus:outline-none focus:border-mew-accent text-sm"
           />
         </div>
 
         {/* Sort toggle */}
-        <div className="flex rounded-lg border border-mew-highlight/50 overflow-hidden">
+        <div className="flex rounded-lg border border-mew-border/50 overflow-hidden">
           <button
             onClick={() => setFilters({ sort: 'newest' })}
             className={`px-4 py-2 text-sm font-medium transition-colors ${
@@ -61,7 +61,7 @@ export function LibraryToolbar({ filters, setFilters, total, isLoggedIn, userSte
         <select
           value={filters.gender}
           onChange={(e) => setFilters({ gender: e.target.value as LibraryFilters['gender'] })}
-          className="bg-mew-bg border border-mew-highlight/50 rounded-lg px-3 py-1.5 text-sm text-mew-text focus:outline-none focus:border-mew-accent"
+          className="bg-mew-bg border border-mew-border/50 rounded-lg px-3 py-1.5 text-sm text-mew-text focus:outline-none focus:border-mew-accent"
         >
           <option value="all">All Genders</option>
           <option value="male">Male</option>
@@ -74,7 +74,7 @@ export function LibraryToolbar({ filters, setFilters, total, isLoggedIn, userSte
           className={`px-3 py-1.5 rounded-lg text-sm font-medium border transition-colors ${
             filters.hasRecommended
               ? 'bg-green-900/40 text-green-400 border-green-800/50'
-              : 'bg-mew-bg text-mew-muted border-mew-highlight/50 hover:text-mew-text'
+              : 'bg-mew-bg text-mew-muted border-mew-border/50 hover:text-mew-text'
           }`}
         >
           Complete Packs
@@ -86,7 +86,7 @@ export function LibraryToolbar({ filters, setFilters, total, isLoggedIn, userSte
           className={`px-3 py-1.5 rounded-lg text-sm font-medium border transition-colors ${
             filters.minScore === 0
               ? 'bg-mew-accent/20 text-mew-accent border-mew-accent/30'
-              : 'bg-mew-bg text-mew-muted border-mew-highlight/50 hover:text-mew-text'
+              : 'bg-mew-bg text-mew-muted border-mew-border/50 hover:text-mew-text'
           }`}
         >
           Hide Negative
@@ -99,7 +99,7 @@ export function LibraryToolbar({ filters, setFilters, total, isLoggedIn, userSte
             className={`px-3 py-1.5 rounded-lg text-sm font-medium border transition-colors ${
               isMyPacks
                 ? 'bg-mew-accent/20 text-mew-accent border-mew-accent/30'
-                : 'bg-mew-bg text-mew-muted border-mew-highlight/50 hover:text-mew-text'
+                : 'bg-mew-bg text-mew-muted border-mew-border/50 hover:text-mew-text'
             }`}
           >
             My Packs

--- a/client/src/components/library/PackCard.tsx
+++ b/client/src/components/library/PackCard.tsx
@@ -79,7 +79,7 @@ export function PackCard({
   };
 
   return (
-    <div className="bg-mew-surface rounded-xl p-5 border border-mew-highlight/30 hover:border-mew-accent/40 transition-colors">
+    <div className="bg-mew-surface rounded-xl p-5 border border-mew-border/30 hover:border-mew-accent/40 transition-colors">
       {/* Header */}
       <div className="flex items-start justify-between mb-3">
         <div className="flex-1 min-w-0">

--- a/client/src/components/pack-builder/PackBuilder.tsx
+++ b/client/src/components/pack-builder/PackBuilder.tsx
@@ -220,7 +220,7 @@ export function PackBuilder() {
       {/* Pack metadata — hidden after build since ZIP is already created */}
       {buildStatus !== 'done' && (
         <>
-          <div className="bg-mew-surface rounded-xl p-6 mb-6 border border-mew-highlight/30">
+          <div className="bg-mew-surface rounded-xl p-6 mb-6 border border-mew-border/30">
             <h2 className="text-2xl font-bold mb-4">Voice Pack Info</h2>
             <div className="space-y-4">
               <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
@@ -232,7 +232,7 @@ export function PackBuilder() {
                     onChange={(e) => setPack((p) => ({ ...p, name: e.target.value }))}
                     placeholder="e.g. Silly Derp Cat"
                     maxLength={50}
-                    className="w-full bg-mew-bg border border-mew-highlight/50 rounded-lg px-4 py-2 text-mew-text placeholder:text-mew-muted/50 focus:outline-none focus:border-mew-accent"
+                    className="w-full bg-mew-bg border border-mew-border/50 rounded-lg px-4 py-2 text-mew-text placeholder:text-mew-muted/50 focus:outline-none focus:border-mew-accent"
                   />
                 </div>
                 <div>
@@ -240,7 +240,7 @@ export function PackBuilder() {
                   <select
                     value={pack.gender}
                     onChange={(e) => setPack((p) => ({ ...p, gender: e.target.value as VoiceGender }))}
-                    className="w-full bg-mew-bg border border-mew-highlight/50 rounded-lg px-4 py-2 text-mew-text focus:outline-none focus:border-mew-accent"
+                    className="w-full bg-mew-bg border border-mew-border/50 rounded-lg px-4 py-2 text-mew-text focus:outline-none focus:border-mew-accent"
                   >
                     <option value="male">Male</option>
                     <option value="female">Female</option>
@@ -260,7 +260,7 @@ export function PackBuilder() {
                   onChange={(e) => setPack((p) => ({ ...p, description: e.target.value }))}
                   placeholder="A goofy cat voice with lots of derp energy"
                   maxLength={200}
-                  className="w-full bg-mew-bg border border-mew-highlight/50 rounded-lg px-4 py-2 text-mew-text placeholder:text-mew-muted/50 focus:outline-none focus:border-mew-accent"
+                  className="w-full bg-mew-bg border border-mew-border/50 rounded-lg px-4 py-2 text-mew-text placeholder:text-mew-muted/50 focus:outline-none focus:border-mew-accent"
                 />
               </div>
             </div>
@@ -268,7 +268,7 @@ export function PackBuilder() {
 
 
           {/* Progress bar */}
-          <div className="bg-mew-surface rounded-xl p-4 mb-6 border border-mew-highlight/30">
+          <div className="bg-mew-surface rounded-xl p-4 mb-6 border border-mew-border/30">
             <div className="flex justify-between text-sm mb-2">
               <span className="text-mew-muted">Progress</span>
               <span className="text-mew-text font-medium">{totalClips} clips recorded</span>
@@ -305,7 +305,7 @@ export function PackBuilder() {
       )}
 
       {/* Build / Download / Publish section */}
-      <div className="bg-mew-surface rounded-xl p-6 border border-mew-highlight/30">
+      <div className="bg-mew-surface rounded-xl p-6 border border-mew-border/30">
         {buildStatus === 'done' && downloadUrl ? (
           <div className="text-center space-y-4">
             <p className="text-green-400 text-lg font-bold">Voice pack built successfully!</p>

--- a/client/src/components/recorder/ActionRecorder.tsx
+++ b/client/src/components/recorder/ActionRecorder.tsx
@@ -129,7 +129,7 @@ export function ActionRecorder({ action, clips, normalClips, onAddClip, onRemove
   const recordingLimit = AUDIO_REQUIREMENTS.recordingLimitSec;
 
   return (
-    <div className="bg-mew-surface rounded-xl p-5 border border-mew-highlight/30">
+    <div className="bg-mew-surface rounded-xl p-5 border border-mew-border/30">
       <div className="flex items-center justify-between mb-2">
         <h3 className="text-lg font-bold text-mew-accent">{action}</h3>
         <span className={`text-sm px-2 py-0.5 rounded-full ${badgeClass}`}>
@@ -181,8 +181,8 @@ export function ActionRecorder({ action, clips, normalClips, onAddClip, onRemove
                   <>
                     <div className="fixed inset-0 z-10" onClick={() => setIsMoveMenuOpen(null)} />
 
-                    <div className="absolute right-0 top-full mt-1 w-40 bg-mew-surface border border-mew-highlight/50 rounded-lg shadow-xl z-20 max-h-64 overflow-y-auto">
-                      <div className="px-3 py-1.5 text-[10px] font-semibold text-mew-muted/60 uppercase tracking-wider border-b border-mew-highlight/20">
+                    <div className="absolute right-0 top-full mt-1 w-40 bg-mew-surface border border-mew-border/50 rounded-lg shadow-xl z-20 max-h-64 overflow-y-auto">
+                      <div className="px-3 py-1.5 text-[10px] font-semibold text-mew-muted/60 uppercase tracking-wider border-b border-mew-border/20">
                         Move to
                       </div>
                       {VOICE_ACTIONS.filter(a => a !== action).map((targetAction) => (
@@ -197,7 +197,7 @@ export function ActionRecorder({ action, clips, normalClips, onAddClip, onRemove
                           {targetAction}
                         </button>
                       ))}
-                      <div className="px-3 py-1.5 text-[10px] font-semibold text-mew-muted/60 uppercase tracking-wider border-t border-b border-mew-highlight/20">
+                      <div className="px-3 py-1.5 text-[10px] font-semibold text-mew-muted/60 uppercase tracking-wider border-t border-b border-mew-border/20">
                         Copy to
                       </div>
                       {VOICE_ACTIONS.filter(a => a !== action).map((targetAction) => (

--- a/client/src/components/recorder/TrimModal.tsx
+++ b/client/src/components/recorder/TrimModal.tsx
@@ -224,7 +224,7 @@ export function TrimModal({ clip, onSave, onClose }: TrimModalProps) {
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/80 backdrop-blur-sm">
-      <div className="bg-mew-surface w-full max-w-2xl rounded-2xl border border-mew-highlight/30 shadow-2xl overflow-hidden">
+      <div className="bg-mew-surface w-full max-w-2xl rounded-2xl border border-mew-border/30 shadow-2xl overflow-hidden">
         <div className="p-6">
           <div className="flex justify-between items-center mb-6">
             <h2 className="text-xl font-bold text-mew-text">Edit Clip</h2>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -11,6 +11,9 @@
   --color-parchment: #C4B8A9;       /* Secondary text — warm muted */
   --color-cream: #E8E0D4;           /* Primary text — warm white */
   --color-ember: #C47A4A;           /* CTA buttons, notifications */
+  --color-border: #FFF;             /* Shared UI border color */
+
+  /* TODO(ui): Split border token by emphasis level if we need softer dividers later. */
 }
 
 body {

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -8,6 +8,7 @@ export default {
           bg: 'var(--color-charcoal)',
           surface: 'var(--color-mushroom)',
           accent: 'var(--color-ember)',
+          border: 'var(--color-border)',
           highlight: 'var(--color-olive)',
           text: 'var(--color-cream)',
           muted: 'var(--color-parchment)',


### PR DESCRIPTION
## Summary
- add a dedicated mew.border color token mapped to a white border variable
- switch client UI border classes from order-mew-highlight/* to order-mew-border/*
- keep existing highlight/background color usage unchanged so only border styling is affected
- add a TODO note to split border emphasis levels if we later want stronger/weaker divider tiers

## Validation
- cd client && npm run lint
- cd client && npm run build