### PR TITLE
Fix six more TODOs across client, desktop, and worker

### DIFF
--- a/client/src/components/library/useLibraryPacks.ts
+++ b/client/src/components/library/useLibraryPacks.ts
@@ -30,6 +30,8 @@ export function useLibraryPacks() {
   const fetchIdRef = useRef(0);
   // Track whether initial load is done
   const hasLoadedRef = useRef(false);
+  // Track packs with an in-flight vote request to prevent double-submit
+  const votingPackIds = useRef(new Set<string>());
   const searchQueryRef = useRef(filters.q);
   // Keep latest non-search filters for q-only debounced fetches
   const nonSearchFiltersRef = useRef({
@@ -138,10 +140,12 @@ export function useLibraryPacks() {
 
   /**
    * Optimistic vote update — mutates local state, fires API, reverts on error.
-   * TODO: Track in-flight vote requests per pack and disable repeat clicks until resolve.
-   * This would prevent accidental double-submit jitter on slow connections.
+   * Ignores repeat clicks while a request for the same pack is in flight.
    */
   const updatePackVote = useCallback(async (packId: string, vote: 1 | -1 | 0) => {
+    if (votingPackIds.current.has(packId)) return;
+    votingPackIds.current.add(packId);
+
     // Snapshot for rollback
     const prevPacks = packs;
 
@@ -166,6 +170,8 @@ export function useLibraryPacks() {
     } catch {
       // Revert on failure
       setPacks(prevPacks);
+    } finally {
+      votingPackIds.current.delete(packId);
     }
   }, [packs]);
 

--- a/client/src/lib/audioConverter.ts
+++ b/client/src/lib/audioConverter.ts
@@ -143,13 +143,18 @@ export function encodeWav(samples: Float32Array, sampleRate: number): Blob {
   writeString(view, 36, 'data');
   view.setUint32(40, dataLength, true);
 
-  // Write PCM samples (convert float32 to int16)
+  // Write PCM samples (convert float32 to int16 with TPDF dithering).
+  // TPDF (Triangular Probability Density Function) dithering adds shaped noise
+  // before quantization, trading a tiny amount of broadband noise for the
+  // elimination of harmonic distortion introduced by simple truncation/rounding.
   let offset = 44;
   for (let i = 0; i < samples.length; i++) {
     const s = Math.max(-1, Math.min(1, samples[i]));
-    // TODO: Add dithering for extra quality instead of simple rounding, especially since we are down-converting to 16-bit.
-    const val = s < 0 ? s * 0x8000 : s * 0x7FFF;
-    view.setInt16(offset, val, true);
+    // Two independent uniform random values → difference has a triangular distribution
+    // over (-1, 1), i.e. one LSB peak-to-peak of dither noise.
+    const dither = Math.random() - Math.random();
+    const raw = (s < 0 ? s * 0x8000 : s * 0x7FFF) + dither;
+    view.setInt16(offset, Math.round(Math.max(-32768, Math.min(32767, raw))), true);
     offset += 2;
   }
 

--- a/desktop/src/hooks/useAppState.ts
+++ b/desktop/src/hooks/useAppState.ts
@@ -169,9 +169,10 @@ export function useAppState() {
     try {
       const packs = await cmd.scanInstalledPacks(state.mewtatorModRoot);
       setState((s) => {
-        // Merge scanned packs: keep existing state for known packs, add new ones
-        // TODO: Also handle packs that were deleted from disk - currently only adds/updates, never removes
         const existing = new Map(s.packs.map((p) => [p.id, p]));
+        // Update/add custom packs found on disk, preserving user settings for known packs.
+        // Custom packs absent from scan results were deleted from disk and are dropped.
+        // Base packs are not managed by MewVoice and are always preserved.
         const merged = packs.map((scanned) => {
           const prev = existing.get(scanned.id);
           if (prev) {
@@ -180,7 +181,8 @@ export function useAppState() {
           }
           return scanned;
         });
-        return { ...s, packs: merged };
+        const basePacks = s.packs.filter((p) => p.isBasePack);
+        return { ...s, packs: [...basePacks, ...merged] };
       });
       setError(null);
     } catch (e) {

--- a/desktop/src/lib/patchBuilder.ts
+++ b/desktop/src/lib/patchBuilder.ts
@@ -28,6 +28,14 @@ export function buildVoicePatch(
     return 'voice_sets.append {\n}\n';
   }
 
+  // GON format requires identifiers to be plain alphanumeric tokens (no whitespace, braces, or quotes).
+  const GON_INVALID = /[\s"'{}[\]]/;
+  for (const p of enabled) {
+    if (GON_INVALID.test(p.id)) {
+      throw new Error(`Pack ID "${p.id}" contains characters that are invalid in GON format (no spaces, quotes, or brackets allowed).`);
+    }
+  }
+
   const lines: string[] = [];
 
   for (const id of muteEntries) {
@@ -39,7 +47,6 @@ export function buildVoicePatch(
   }
 
   // TODO: Consider reading any existing catgen.gon.patch and merging lines instead of overwriting, to preserve other mod changes if they exist.
-  // TODO: Add validation to ensure pack IDs don't contain invalid characters for GON format (e.g., spaces, special characters)
   return `voice_sets.append {\n${lines.join('\n')}\n}\n`;
 }
 

--- a/worker/src/lib/wav.ts
+++ b/worker/src/lib/wav.ts
@@ -39,10 +39,24 @@ export function validateWav(data: ArrayBuffer): WavInfo {
     throw new Error('Invalid WAV (missing fmt chunk)');
   }
 
-  // TODO: Add better support or explicit error messages for Float PCM (format 3) or other non-standard encodings to guide the user.
   const audioFormat = view.getUint16(20, true);
+  if (audioFormat === 3) {
+    throw new Error(
+      'Invalid WAV format: IEEE Float PCM (format 3) is not supported. ' +
+      'Please re-export your audio as 16-bit integer PCM (format 1).',
+    );
+  }
+  if (audioFormat === 6 || audioFormat === 7) {
+    throw new Error(
+      `Invalid WAV format: ${audioFormat === 6 ? 'A-law' : 'μ-law'} encoding is not supported. ` +
+      'Please re-export your audio as 16-bit integer PCM.',
+    );
+  }
   if (audioFormat !== 1) {
-    throw new Error(`Invalid WAV format (expected PCM=1, got ${audioFormat})`);
+    throw new Error(
+      `Invalid WAV format (got ${audioFormat}, expected PCM=1). ` +
+      'Please re-export your audio as 16-bit integer PCM.',
+    );
   }
 
   const channels = view.getUint16(22, true);

--- a/worker/src/routes/voicepacks.ts
+++ b/worker/src/routes/voicepacks.ts
@@ -292,10 +292,10 @@ voicepackRoutes.get('/', async (c) => {
     hasMore: offset + limit < total,
   });
 
-  // Cache anonymous responses for 1 minute
-  // TODO: Make this TTL configurable via environment variables.
+  // Cache anonymous responses; TTL is configurable via CACHE_TTL_SECONDS env var (default 60 s).
+  const cacheTtl = Math.max(0, parseInt(c.env.CACHE_TTL_SECONDS || '60', 10) || 60);
   if (!user) {
-    response.headers.set('Cache-Control', 'public, max-age=60');
+    response.headers.set('Cache-Control', `public, max-age=${cacheTtl}`);
     c.executionCtx.waitUntil(cache.put(cacheKey, response.clone()));
   } else {
     response.headers.set('Cache-Control', 'private, no-cache');

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -6,6 +6,8 @@ export interface Env {
   STEAM_API_KEY: string;
   SITE_ORIGIN: string;
   DEV_STEAM_ID?: string;
+  /** Cache TTL in seconds for anonymous pack-list responses. Defaults to 60. */
+  CACHE_TTL_SECONDS?: string;
 }
 
 /** Decoded JWT payload */


### PR DESCRIPTION
- wav.ts: give distinct error messages for Float PCM (format 3), A-law/μ-law (formats 6/7), and other non-PCM encodings so users know exactly what to fix.

- worker/types.ts + voicepacks.ts: add optional CACHE_TTL_SECONDS env var so the anonymous pack-list cache TTL is configurable without a code redeploy (defaults to 60 s).

- patchBuilder.ts: validate pack IDs before building the GON patch and throw a clear error if any ID contains whitespace, quotes, or brackets that would break the GON format.

- useAppState.ts: during scanPacks, explicitly preserve base packs (which are never returned by the Tauri scan command) and drop custom packs that are no longer present on disk — resolving the "never removes" stale-state issue.

- useLibraryPacks.ts: guard updatePackVote with a per-pack in-flight Set; a second click while a request is pending is silently ignored and the lock is released in a finally block after the request settles.

- audioConverter.ts: replace plain rounding with TPDF dithering when quantizing float32 samples to 16-bit PCM, eliminating harmonic distortion at the cost of a tiny amount of broadband noise.