### PR TITLE
Fix sidebar and panel toolbars scrolling with content

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -32,7 +32,7 @@ function App() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center min-h-screen">
+      <div className="flex items-center justify-center h-screen">
         <p className="text-mew-muted">Loading...</p>
       </div>
     );

--- a/desktop/src/components/layout/Shell.tsx
+++ b/desktop/src/components/layout/Shell.tsx
@@ -20,16 +20,16 @@ export default function Shell({
   children,
 }: ShellProps) {
   return (
-    <div className="flex min-h-screen">
+    <div className="flex h-screen overflow-hidden">
       <Sidebar
         activePanel={activePanel}
         onNavigate={onNavigate}
         patchDirty={patchDirty}
       />
 
-      <main className="flex-1 flex flex-col min-h-screen">
+      <main className="flex-1 flex flex-col min-w-0 overflow-hidden">
         {error && (
-          <div className="bg-red-900/40 border-b border-red-700/50 px-4 py-2 flex items-center justify-between">
+          <div className="flex-shrink-0 bg-red-900/40 border-b border-red-700/50 px-4 py-2 flex items-center justify-between">
             <span className="text-sm text-red-300 selectable">{error}</span>
             <button
               onClick={onClearError}
@@ -40,10 +40,8 @@ export default function Shell({
           </div>
         )}
 
-        <div className="flex-1 p-6">
-          <div className="h-full overflow-y-auto">
-            {children}
-          </div>
+        <div className="flex-1 flex flex-col min-h-0 p-6">
+          {children}
         </div>
       </main>
     </div>

--- a/desktop/src/components/layout/Sidebar.tsx
+++ b/desktop/src/components/layout/Sidebar.tsx
@@ -18,7 +18,7 @@ import { APP_VERSION } from '@/lib/version';
 
 export default function Sidebar({ activePanel, onNavigate, patchDirty }: SidebarProps) {
   return (
-    <nav className="w-52 min-h-screen bg-mew-surface border-r border-mew-highlight/30 flex flex-col">
+    <nav className="w-52 flex-shrink-0 bg-mew-surface border-r border-mew-highlight/30 flex flex-col">
       <div className="p-4 border-b border-mew-highlight/30">
         <h1 className="text-lg font-semibold text-mew-accent">MewVoice</h1>
         <p className="text-xs text-mew-muted">Voice Pack Manager</p>

--- a/desktop/src/components/panels/BasePacksPanel.tsx
+++ b/desktop/src/components/panels/BasePacksPanel.tsx
@@ -205,7 +205,8 @@ export default function BasePacksPanel({
   const mutedCount = mutedBasePacks.length;
 
   return (
-    <div>
+    <div className="flex flex-col min-h-0 flex-1">
+      <div className="flex-shrink-0">
       <div className="flex items-center justify-between mb-6">
         <div>
           <h2 className="text-xl font-semibold">Base Game Voices</h2>
@@ -249,9 +250,10 @@ export default function BasePacksPanel({
           ))}
         </div>
       </div>
+      </div>
 
       {/* Pack list */}
-<div className="space-y-1 h-full overflow-y-auto">
+<div className="flex-1 min-h-0 space-y-1 overflow-y-auto">
         {filtered.map((pack) => {
           const isMuted = mutedBasePacks.includes(pack.id);
           return (

--- a/desktop/src/components/panels/CommunityLibraryPanel.tsx
+++ b/desktop/src/components/panels/CommunityLibraryPanel.tsx
@@ -191,7 +191,8 @@ export default function CommunityLibraryPanel({
   }, [playingPackId]);
 
   return (
-    <div>
+    <div className="flex flex-col min-h-0 flex-1">
+      <div className="flex-shrink-0">
       <div className="flex items-start justify-between mb-6 gap-4">
         <div>
           <h2 className="text-xl font-semibold">Community Library</h2>
@@ -251,7 +252,9 @@ export default function CommunityLibraryPanel({
           <option value="top">Top score</option>
         </select>
       </div>
+      </div>
 
+      <div className="flex-1 min-h-0 overflow-y-auto">
       {initialLoading ? (
         <div className="text-center py-16 text-mew-muted">Loading community packs...</div>
       ) : error ? (
@@ -353,6 +356,7 @@ export default function CommunityLibraryPanel({
           </div>
         </>
       )}
+      </div>
     </div>
   );
 }

--- a/desktop/src/components/panels/InstalledPacksPanel.tsx
+++ b/desktop/src/components/panels/InstalledPacksPanel.tsx
@@ -90,8 +90,8 @@ export default function InstalledPacksPanel({
   }
 
   return (
-    <div>
-      <div className="flex items-center justify-between mb-6">
+    <div className="flex flex-col min-h-0 flex-1">
+      <div className="flex-shrink-0 flex items-center justify-between mb-6">
         <div>
           <h2 className="text-xl font-semibold">Installed Voice Packs</h2>
           <p className="text-sm text-mew-muted mt-1">
@@ -125,6 +125,7 @@ export default function InstalledPacksPanel({
         </div>
       </div>
 
+      <div className="flex-1 min-h-0 overflow-y-auto">
       {packs.length === 0 ? (
         <div className="text-center py-12 border border-dashed border-mew-highlight/30 rounded-lg">
           <p className="text-mew-muted">No voice packs found</p>
@@ -151,6 +152,7 @@ export default function InstalledPacksPanel({
           ))}
         </div>
       )}
+      </div>
 
       {showOpenFallbackModal && (
         <div className="fixed inset-0 z-50 bg-black/60 flex items-center justify-center p-4">

--- a/desktop/src/components/panels/SettingsPanel.tsx
+++ b/desktop/src/components/panels/SettingsPanel.tsx
@@ -117,8 +117,10 @@ export default function SettingsPanel({
   };
 
   return (
-    <div className="max-w-lg">
-      <h2 className="text-xl font-semibold mb-6">Settings</h2>
+    <div className="flex flex-col min-h-0 flex-1">
+      <h2 className="flex-shrink-0 text-xl font-semibold mb-6">Settings</h2>
+
+      <div className="flex-1 min-h-0 overflow-y-auto max-w-lg">
 
       {/* Mod root path */}
       <div className="mb-6">
@@ -259,6 +261,7 @@ export default function SettingsPanel({
             </button>
           </div>
         )}
+      </div>
       </div>
     </div>
   );

--- a/desktop/src/components/panels/VoiceRegistrationPanel.tsx
+++ b/desktop/src/components/panels/VoiceRegistrationPanel.tsx
@@ -35,7 +35,8 @@ export default function VoiceRegistrationPanel({
   }
 
   return (
-    <div>
+    <div className="flex flex-col min-h-0 flex-1">
+      <div className="flex-shrink-0">
       <div className="flex items-center justify-between mb-6">
         <div>
           <h2 className="text-xl font-semibold">Voice Registration</h2>
@@ -61,7 +62,9 @@ export default function VoiceRegistrationPanel({
           Voice patch is out of sync with your current settings. Click "Regenerate" to apply changes.
         </div>
       )}
+      </div>
 
+      <div className="flex-1 min-h-0 overflow-y-auto">
       {/* Spawn distribution table */}
       {enabledPacks.length > 0 ? (
         <div className="mb-6">
@@ -125,6 +128,7 @@ export default function VoiceRegistrationPanel({
       <p className="mt-3 text-xs text-mew-muted/60">
         Write target: {modRoot}/MewVoice/data/catgen.gon.patch
       </p>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Constrain the app layout to viewport height so that the sidebar and per-panel toolbars (buttons, search bars, filters) remain fixed in place while only the data area scrolls.

- Shell: use h-screen + overflow-hidden instead of min-h-screen
- Sidebar: remove min-h-screen, use flex-shrink-0
- Each panel: split into flex-shrink-0 header and flex-1 overflow-y-auto data region
- Use flex-1 (not h-full) on panel roots so tests render correctly