### PR TITLE
Persist recording session to localStorage to survive page refreshes

### DIFF
--- a/client/src/components/pack-builder/PackBuilder.tsx
+++ b/client/src/components/pack-builder/PackBuilder.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import {
   VoicePack,
   VoiceAction,
@@ -9,9 +9,11 @@ import {
   ACTION_RECOMMENDED_CLIPS,
 } from '@/types/voicepack';
 import { ActionRecorder } from '@/components/recorder/ActionRecorder';
+import { ResumeSessionModal } from '@/components/pack-builder/ResumeSessionModal';
 import { uploadVoicePack, publishVoicePack } from '@/lib/api';
 import { convertToGameWav } from '@/lib/audioConverter';
 import { useAuth } from '@/hooks/useAuth';
+import { hasSession, sessionSavedAt, saveSession, loadSession, clearSession } from '@/lib/sessionCache';
 
 function createEmptyClips(): Record<VoiceAction, AudioClip[]> {
   const clips: Partial<Record<VoiceAction, AudioClip[]>> = {};
@@ -31,6 +33,46 @@ export function PackBuilder() {
   });
 
   const packAuthor = pack.author || user?.personaName || '';
+
+  // Session persistence -------------------------------------------------------
+  const [resumeModalSavedAt, setResumeModalSavedAt] = useState<Date | null>(null);
+  const autoSaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // On mount: check for a saved session and prompt the user.
+  useEffect(() => {
+    if (hasSession()) {
+      setResumeModalSavedAt(sessionSavedAt());
+    }
+  }, []);
+
+  // Auto-save whenever the pack changes (debounced 1 s).
+  // Only persist once the user has at least one clip so we don't overwrite a
+  // real session with a blank slate on initial render.
+  useEffect(() => {
+    const totalClipsNow = Object.values(pack.clips).reduce((s, a) => s + a.length, 0);
+    if (totalClipsNow === 0) return;
+
+    if (autoSaveTimer.current) clearTimeout(autoSaveTimer.current);
+    autoSaveTimer.current = setTimeout(() => {
+      saveSession(pack);
+    }, 1000);
+
+    return () => {
+      if (autoSaveTimer.current) clearTimeout(autoSaveTimer.current);
+    };
+  }, [pack]);
+
+  const handleResume = useCallback(async () => {
+    const saved = await loadSession();
+    if (saved) setPack(saved);
+    setResumeModalSavedAt(null);
+  }, []);
+
+  const handleDiscard = useCallback(() => {
+    clearSession();
+    setResumeModalSavedAt(null);
+  }, []);
+  // ---------------------------------------------------------------------------
 
   const [buildStatus, setBuildStatus] = useState<'idle' | 'converting' | 'building' | 'done' | 'error'>('idle');
   const [conversionProgress, setConversionProgress] = useState({ done: 0, total: 0 });
@@ -174,6 +216,7 @@ export function PackBuilder() {
       setBuildId(result.id);
       setDownloadUrl(result.downloadUrl);
       setBuildStatus('done');
+      clearSession();
     } catch (err) {
       setErrorMsg(err instanceof Error ? err.message : 'Build failed');
       setBuildStatus('error');
@@ -198,6 +241,7 @@ export function PackBuilder() {
   };
 
   const handleReset = () => {
+    clearSession();
     setPack({
       name: '',
       author: user?.personaName || '',
@@ -214,6 +258,13 @@ export function PackBuilder() {
 
   return (
     <div className="max-w-4xl mx-auto">
+      {resumeModalSavedAt && (
+        <ResumeSessionModal
+          savedAt={resumeModalSavedAt}
+          onResume={handleResume}
+          onDiscard={handleDiscard}
+        />
+      )}
       {/* Pack metadata — hidden after build since ZIP is already created */}
       {buildStatus !== 'done' && (
         <>

--- a/client/src/components/pack-builder/ResumeSessionModal.tsx
+++ b/client/src/components/pack-builder/ResumeSessionModal.tsx
@@ -1,0 +1,47 @@
+interface ResumeSessionModalProps {
+  savedAt: Date;
+  onResume: () => void;
+  onDiscard: () => void;
+}
+
+export function ResumeSessionModal({ savedAt, onResume, onDiscard }: ResumeSessionModalProps) {
+  const timeAgo = formatTimeAgo(savedAt);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+      <div className="bg-mew-surface border border-mew-border/50 rounded-xl p-6 max-w-sm w-full mx-4 shadow-xl">
+        <h2 className="text-xl font-bold mb-2">Resume previous session?</h2>
+        <p className="text-mew-muted text-sm mb-6">
+          You have an unsaved recording session from{' '}
+          <span className="text-mew-text">{timeAgo}</span>. Would you like to pick up where you left
+          off, or start fresh?
+        </p>
+        <div className="flex flex-col gap-3">
+          <button
+            onClick={onResume}
+            className="w-full bg-mew-accent hover:brightness-125 text-white py-2.5 px-4 rounded-lg font-semibold transition-all"
+          >
+            Resume session
+          </button>
+          <button
+            onClick={onDiscard}
+            className="w-full bg-transparent hover:bg-mew-bg border border-mew-border/50 text-mew-muted hover:text-mew-text py-2.5 px-4 rounded-lg font-semibold transition-all"
+          >
+            Start fresh
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function formatTimeAgo(date: Date): string {
+  const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
+  if (seconds < 60) return 'just now';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes} minute${minutes === 1 ? '' : 's'} ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} hour${hours === 1 ? '' : 's'} ago`;
+  const days = Math.floor(hours / 24);
+  return `${days} day${days === 1 ? '' : 's'} ago`;
+}

--- a/client/src/lib/sessionCache.ts
+++ b/client/src/lib/sessionCache.ts
@@ -1,0 +1,160 @@
+/**
+ * Persists the current pack-builder session to localStorage so recordings
+ * survive an accidental page refresh.
+ *
+ * Blobs are serialised to base64 strings because localStorage only holds
+ * plain text.  Large packs may approach the ~5 MB quota; the save is
+ * wrapped in a try/catch so a QuotaExceededError is silently swallowed
+ * rather than crashing the app.
+ */
+
+import { VoicePack, VoiceAction, VoiceGender, AudioClip, VOICE_ACTIONS } from '@/types/voicepack';
+
+const SESSION_KEY = 'mewvoice_session';
+
+interface SerializedClip {
+  id: string;
+  action: VoiceAction;
+  base64: string;
+  mimeType: string;
+  duration: number;
+  fileName: string;
+  isValid: boolean;
+  validationErrors: string[];
+  validationWarnings: string[];
+}
+
+interface SerializedSession {
+  name: string;
+  author: string;
+  gender: VoiceGender;
+  description: string;
+  clips: Record<VoiceAction, SerializedClip[]>;
+  savedAt: number;
+}
+
+// --- helpers ---
+
+async function blobToBase64(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve((reader.result as string).split(',')[1]);
+    reader.onerror = reject;
+    reader.readAsDataURL(blob);
+  });
+}
+
+function base64ToBlob(base64: string, mimeType: string): Blob {
+  const bytes = Uint8Array.from(atob(base64), (c) => c.charCodeAt(0));
+  return new Blob([bytes], { type: mimeType });
+}
+
+// --- public API ---
+
+/** Returns true if a saved session exists in localStorage. */
+export function hasSession(): boolean {
+  return localStorage.getItem(SESSION_KEY) !== null;
+}
+
+/** Returns the ISO date string of the saved session, or null. */
+export function sessionSavedAt(): Date | null {
+  const raw = localStorage.getItem(SESSION_KEY);
+  if (!raw) return null;
+  try {
+    const parsed: SerializedSession = JSON.parse(raw);
+    return new Date(parsed.savedAt);
+  } catch {
+    return null;
+  }
+}
+
+/** Removes the saved session from localStorage. */
+export function clearSession(): void {
+  localStorage.removeItem(SESSION_KEY);
+}
+
+/**
+ * Serialises the pack (including audio blobs) to localStorage.
+ * Silently fails if the storage quota is exceeded.
+ */
+export async function saveSession(pack: VoicePack): Promise<void> {
+  const serializedClips: Partial<Record<VoiceAction, SerializedClip[]>> = {};
+
+  for (const action of VOICE_ACTIONS) {
+    const clips = pack.clips[action];
+    const serialized: SerializedClip[] = [];
+    for (const clip of clips) {
+      const base64 = await blobToBase64(clip.blob);
+      serialized.push({
+        id: clip.id,
+        action: clip.action,
+        base64,
+        mimeType: clip.blob.type || 'audio/webm',
+        duration: clip.duration,
+        fileName: clip.fileName,
+        isValid: clip.isValid,
+        validationErrors: clip.validationErrors,
+        validationWarnings: clip.validationWarnings,
+      });
+    }
+    serializedClips[action] = serialized;
+  }
+
+  const session: SerializedSession = {
+    name: pack.name,
+    author: pack.author,
+    gender: pack.gender,
+    description: pack.description,
+    clips: serializedClips as Record<VoiceAction, SerializedClip[]>,
+    savedAt: Date.now(),
+  };
+
+  try {
+    localStorage.setItem(SESSION_KEY, JSON.stringify(session));
+  } catch {
+    // QuotaExceededError — too much audio data; fail silently
+  }
+}
+
+/**
+ * Deserialises a previously saved session from localStorage.
+ * Returns null if no session exists or parsing fails.
+ */
+export async function loadSession(): Promise<VoicePack | null> {
+  const raw = localStorage.getItem(SESSION_KEY);
+  if (!raw) return null;
+
+  try {
+    const session: SerializedSession = JSON.parse(raw);
+
+    const clips: Partial<Record<VoiceAction, AudioClip[]>> = {};
+    for (const action of VOICE_ACTIONS) {
+      const serializedClips = session.clips[action] ?? [];
+      clips[action] = serializedClips.map((sc) => {
+        const blob = base64ToBlob(sc.base64, sc.mimeType);
+        return {
+          id: sc.id,
+          action: sc.action,
+          blob,
+          url: URL.createObjectURL(blob),
+          duration: sc.duration,
+          fileName: sc.fileName,
+          isValid: sc.isValid,
+          validationErrors: sc.validationErrors,
+          validationWarnings: sc.validationWarnings,
+        };
+      });
+    }
+
+    return {
+      name: session.name,
+      author: session.author,
+      gender: session.gender,
+      description: session.description,
+      clips: clips as Record<VoiceAction, AudioClip[]>,
+    };
+  } catch {
+    clearSession();
+    return null;
+  }
+}


### PR DESCRIPTION
Adds auto-save of the current pack-builder state (including audio blobs serialised as base64) to localStorage after every clip change (debounced 1 s). On the next page load a modal prompts the user to resume or discard the saved session. The cache is cleared on successful build and on reset.

- client/src/lib/sessionCache.ts: new utility for save/load/clear
- client/src/components/pack-builder/ResumeSessionModal.tsx: prompt modal
- client/src/components/pack-builder/PackBuilder.tsx: wires auto-save and resume/discard flow