### PR TITLE
Add Linux release build framework (AppImage + .deb)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,15 @@ jobs:
   publish-tauri:
     permissions:
       contents: write
-    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: windows-latest
+            label: windows
+          - platform: ubuntu-22.04
+            label: linux
+    runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v6
       - name: setup node
@@ -16,6 +24,18 @@ jobs:
           node-version: lts/*
       - name: install Rust stable
         uses: dtolnay/rust-toolchain@stable
+
+      # ── Linux system dependencies (Tauri / WebKitGTK) ──────────────────
+      - name: install Linux dependencies
+        if: matrix.label == 'linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf
+
       - name: install frontend dependencies
         run: npm install
         working-directory: ./desktop
@@ -36,8 +56,9 @@ jobs:
 
       # ── Hash (AV reputation runs in reputation.yml on release publish) ──────
 
-      - name: Locate installer and compute SHA-256
-        id: hash
+      - name: Locate installer and compute SHA-256 (Windows)
+        if: matrix.label == 'windows'
+        id: hash-windows
         shell: pwsh
         run: |
           $exe = Get-ChildItem -Recurse "desktop/src-tauri/target/release/bundle/nsis" `
@@ -60,12 +81,47 @@ jobs:
           "sha_file=$shaFile"             | Out-File -Append $env:GITHUB_OUTPUT
           "installer_name=$($exe.Name)"  | Out-File -Append $env:GITHUB_OUTPUT
 
-      - name: Upload SHA-256 checksum to release
+      - name: Locate installer and compute SHA-256 (Linux)
+        if: matrix.label == 'linux'
+        id: hash-linux
+        shell: bash
+        run: |
+          # Prefer AppImage, fall back to .deb
+          artifact=$(find desktop/src-tauri/target/release/bundle/appimage \
+                     -name "*.AppImage" 2>/dev/null | head -1)
+          if [ -z "$artifact" ]; then
+            artifact=$(find desktop/src-tauri/target/release/bundle/deb \
+                       -name "*.deb" 2>/dev/null | head -1)
+          fi
+          if [ -z "$artifact" ]; then
+            echo "::error::No Linux installer artifact found"
+            exit 1
+          fi
+
+          hash=$(sha256sum "$artifact" | awk '{print $1}')
+          name=$(basename "$artifact")
+          sha_file="$RUNNER_TEMP/${name}.sha256"
+          echo "$hash  $name" > "$sha_file"
+
+          echo "sha256=$hash"               >> "$GITHUB_OUTPUT"
+          echo "installer_path=$artifact"   >> "$GITHUB_OUTPUT"
+          echo "sha_file=$sha_file"         >> "$GITHUB_OUTPUT"
+          echo "installer_name=$name"       >> "$GITHUB_OUTPUT"
+
+      - name: Upload SHA-256 checksum to release (Windows)
+        if: matrix.label == 'windows'
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           $version = (Get-Content desktop/src-tauri/tauri.conf.json | ConvertFrom-Json).version
-          gh release upload "MewVoice-v$version" "${{ steps.hash.outputs.sha_file }}" --clobber
+          gh release upload "MewVoice-v$version" "${{ steps.hash-windows.outputs.sha_file }}" --clobber
 
-
+      - name: Upload SHA-256 checksum to release (Linux)
+        if: matrix.label == 'linux'
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          version=$(jq -r '.version' desktop/src-tauri/tauri.conf.json)
+          gh release upload "MewVoice-v$version" "${{ steps.hash-linux.outputs.sha_file }}" --clobber

--- a/.github/workflows/reputation.yml
+++ b/.github/workflows/reputation.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Fetch hash from release assets
+      - name: Fetch hashes from release assets
         id: hash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -21,17 +21,38 @@ jobs:
             --pattern "*.sha256" \
             --dir "$RUNNER_TEMP"
 
-          sha_file=$(find "$RUNNER_TEMP" -name "*.sha256" | head -1)
-          content=$(cat "$sha_file")
-          # File format written by release.yml: "<hash>  <filename>"
-          hash=$(awk '{print $1}' <<< "$content")
-          name=$(awk '{print $2}' <<< "$content")
+          # Build a table of all checksums (one per platform artifact)
+          table=""
+          vt_hashes=""
+          for sha_file in "$RUNNER_TEMP"/*.sha256; do
+            [ -f "$sha_file" ] || continue
+            content=$(cat "$sha_file")
+            hash=$(awk '{print $1}' <<< "$content")
+            name=$(awk '{print $2}' <<< "$content" | tr -d '[:space:]')
+            table="${table}| \`${name}\` | \`${hash}\` |\n"
+            vt_hashes="${vt_hashes}${hash}:${name}\n"
+          done
 
-          # Trim any trailing whitespace/newlines from the filename
-          name=$(echo "$name" | tr -d '[:space:]')
+          # Export first hash for backwards compat (Windows installer)
+          first_file=$(find "$RUNNER_TEMP" -name "*.sha256" | sort | head -1)
+          first_hash=$(awk '{print $1}' < "$first_file")
+          first_name=$(awk '{print $2}' < "$first_file" | tr -d '[:space:]')
 
-          echo "sha256=$hash"        >> "$GITHUB_OUTPUT"
-          echo "installer_name=$name" >> "$GITHUB_OUTPUT"
+          echo "sha256=$first_hash"        >> "$GITHUB_OUTPUT"
+          echo "installer_name=$first_name" >> "$GITHUB_OUTPUT"
+
+          # Multi-line outputs for the summary
+          {
+            echo "table<<TABLEEOF"
+            echo -e "$table"
+            echo "TABLEEOF"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "vt_hashes<<VTEOF"
+            echo -e "$vt_hashes"
+            echo "VTEOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Submit to VirusTotal
         # Fix: Map the secret to env first, then check env in the 'if'
@@ -40,48 +61,49 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: env.VT_API_KEY != ''
         run: |
-          hash="${{ steps.hash.outputs.sha256 }}"
-          name="${{ steps.hash.outputs.installer_name }}"
           tag="${{ github.event.release.tag_name }}"
 
-          http_code=$(curl -s -o /dev/null -w "%{http_code}" \
-            -H "x-apikey: $VT_API_KEY" \
-            "https://www.virustotal.com/api/v3/files/$hash")
+          # Submit each artifact to VirusTotal
+          while IFS=: read -r hash name; do
+            [ -z "$hash" ] && continue
+            echo "--- Checking $name ($hash) ---"
 
-          if [ "$http_code" = "200" ]; then
-            echo "Hash already known to VirusTotal — skipping upload."
-          else
-            echo "Hash not yet known — downloading installer from release and uploading..."
-            gh release download "$tag" \
-              --repo "${{ github.repository }}" \
-              --pattern "$name" \
-              --dir "$RUNNER_TEMP"
-
-            analysis_id=$(curl -s \
+            http_code=$(curl -s -o /dev/null -w "%{http_code}" \
               -H "x-apikey: $VT_API_KEY" \
-              -F "file=@$RUNNER_TEMP/$name" \
-              "https://www.virustotal.com/api/v3/files" \
-              | jq -r '.data.id')
-            echo "Queued. Analysis ID: $analysis_id"
-          fi
+              "https://www.virustotal.com/api/v3/files/$hash")
 
-          echo "Results: https://www.virustotal.com/gui/file/$hash"
+            if [ "$http_code" = "200" ]; then
+              echo "Hash already known to VirusTotal — skipping upload."
+            else
+              echo "Hash not yet known — downloading and uploading..."
+              gh release download "$tag" \
+                --repo "${{ github.repository }}" \
+                --pattern "$name" \
+                --dir "$RUNNER_TEMP"
+
+              analysis_id=$(curl -s \
+                -H "x-apikey: $VT_API_KEY" \
+                -F "file=@$RUNNER_TEMP/$name" \
+                "https://www.virustotal.com/api/v3/files" \
+                | jq -r '.data.id')
+              echo "Queued. Analysis ID: $analysis_id"
+            fi
+
+            echo "Results: https://www.virustotal.com/gui/file/$hash"
+          done <<< "${{ steps.hash.outputs.vt_hashes }}"
 
       - name: Write job summary
         run: |
-          hash="${{ steps.hash.outputs.sha256 }}"
-          name="${{ steps.hash.outputs.installer_name }}"
           tag="${{ github.event.release.tag_name }}"
           cat >> "$GITHUB_STEP_SUMMARY" << EOF
           ## Release Checksums
 
           | File | SHA-256 |
           |------|---------|
-          | \`$name\` | \`$hash\` |
+          ${{ steps.hash.outputs.table }}
 
           ## AV Reputation Submissions
 
-          - **VirusTotal**: https://www.virustotal.com/gui/file/$hash
-          - **Microsoft WDSI** *(manual)*: https://www.microsoft.com/en-us/wdsi/filesubmission
-            - Submit hash \`$hash\` or upload the installer directly.
+          - **VirusTotal**: check each hash above at https://www.virustotal.com
+          - **Microsoft WDSI** *(manual, Windows only)*: https://www.microsoft.com/en-us/wdsi/filesubmission
           EOF

--- a/client/src/components/pack-builder/PackBuilder.tsx
+++ b/client/src/components/pack-builder/PackBuilder.tsx
@@ -35,15 +35,10 @@ export function PackBuilder() {
   const packAuthor = pack.author || user?.personaName || '';
 
   // Session persistence -------------------------------------------------------
-  const [resumeModalSavedAt, setResumeModalSavedAt] = useState<Date | null>(null);
+  const [resumeModalSavedAt, setResumeModalSavedAt] = useState<Date | null>(() =>
+    hasSession() ? sessionSavedAt() : null
+  );
   const autoSaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  // On mount: check for a saved session and prompt the user.
-  useEffect(() => {
-    if (hasSession()) {
-      setResumeModalSavedAt(sessionSavedAt());
-    }
-  }, []);
 
   // Auto-save whenever the pack changes (debounced 1 s).
   // Only persist once the user has at least one clip so we don't overwrite a

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -34,8 +34,19 @@
       "icons/128x128.png",
       "icons/128x128@2x.png",
       "icons/icon.icns",
-      "icons/icon.ico"
-    ]
+      "icons/icon.ico",
+      "icons/icon.png"
+    ],
+    "linux": {
+      "deb": {
+        "depends": ["libwebkit2gtk-4.1-0", "libappindicator3-1"],
+        "section": "games",
+        "desktopTemplate": null
+      },
+      "appimage": {
+        "bundleMediaFramework": true
+      }
+    }
   },
   "plugins": {
     "updater": {

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -2141,9 +2141,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.3.tgz",
-      "integrity": "sha512-SFsVSjp8sj5UumXOOFlkZOG6XS9SJDKw0TbwFeV+AJ8xlST8kxK5Z/5EYa111UY8732lK2S/xB653ceuaoGwpg==",
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
+      "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"


### PR DESCRIPTION
Extend the release pipeline to produce Linux artifacts alongside existing Windows builds:

- release.yml: Add ubuntu-22.04 matrix entry with WebKitGTK and system dependency installation, platform-specific hash steps
- tauri.conf.json: Add linux bundle config (deb depends, appimage media framework), include icon.png for Linux desktop entries
- reputation.yml: Process all .sha256 checksum files so both Windows and Linux artifacts get AV-scanned

The Rust codebase is already fully cross-platform (PathBuf everywhere, no Windows-specific APIs), so no backend changes are needed.

Resolves #54 